### PR TITLE
run supervisor as vapor

### DIFF
--- a/4.0/docs/deploy/supervisor.md
+++ b/4.0/docs/deploy/supervisor.md
@@ -9,6 +9,28 @@ sudo apt-get update
 sudo apt-get install supervisor
 ```
 
+Supervisor can currently only run as the `root` user. You can exit and login as root, or create a new group and add `vapor` to it.
+
+```sh
+groupadd supervisor
+usermod -a vapor -G supervisor
+```
+
+Log out, log back in, and edit the the supervisord configuration file (/etc/supervisor/supervisor.conf) unix_http_server section:
+
+```sh
+[unix_http_server]
+file=/var/run/supervisor.sock ; (the path to the socket file)
+chmod=0770 ; socket file mode (default 0700)
+chown=root:supervisor
+```
+
+Finally, restart Supervisor:
+
+```sh
+supervisorctl reload
+```
+
 ## Configure
 
 Each Vapor app on your server should have its own configuration file. For an example `Hello` project, the configuration file would be located at `/etc/supervisor/conf.d/hello.conf`

--- a/4.0/docs/deploy/supervisor.md
+++ b/4.0/docs/deploy/supervisor.md
@@ -9,14 +9,14 @@ sudo apt-get update
 sudo apt-get install supervisor
 ```
 
-Supervisor can currently only run as the `root` user. You can exit and login as root, or create a new group and add `vapor` to it.
+Once installed, Supervisor is only configured to run as the `root` user. It is considered a good practice to not your services as `root`. If you created a `vapor` user earlier, you can add it to a group that can run Supervisor thusly:
 
 ```sh
 groupadd supervisor
 usermod -a vapor -G supervisor
 ```
 
-Log out, log back in, and edit the the supervisord configuration file (/etc/supervisor/supervisor.conf) unix_http_server section:
+Log out, log back in, and edit the the supervisord configuration file (`/etc/supervisor/supervisor.conf`) `unix_http_server` section. These changes will grant the newly created group `supervisor` access to the service.
 
 ```sh
 [unix_http_server]


### PR DESCRIPTION
When following the instructions at /docs/4.0/docs/deploy/supervisor.md, the user will encounter the following error when running `supervisorctl reread`:
```
error: <class 'socket.error'>, [Errno 13] Permission denied: file: /usr/lib/python2.7/socket.py line: 228
```
This is due to the "vapor" user not having the necessary permissions to run supervisorctl. Directions for enabling these permissions are outlined here: `Supervisor/supervisor#173`

Docs updated to guide user through giving permissions to `vapor` user.