### PR TITLE
Swift 5.2 requirement

### DIFF
--- a/4.0/docs/deploy/digital-ocean.md
+++ b/4.0/docs/deploy/digital-ocean.md
@@ -13,7 +13,7 @@ Under distributions, select Ubuntu 18.04 LTS.
 ![Ubuntu Distro](../images/digital-ocean-distributions-ubuntu-18.png)
 
 !!! note 
-	You may select any version of Ubuntu that Swift supports. At the time of writing, Swift 5.1 supports Ubuntu 14.04, 16.04, and 18.04. You can check which operating systems are officially supported on the [Swift Releases](https://swift.org/download/#releases) page.
+	You may select any version of Ubuntu that Swift supports. At the time of writing, Swift 5.2 supports 16.04 and 18.04. You can check which operating systems are officially supported on the [Swift Releases](https://swift.org/download/#releases) page.
 
 After selecting the distribution, choose any plan and datacenter region you prefer. Then setup an SSH key to access the server after it is created. Finally, click create Droplet and wait for the new server to spin up.
 
@@ -82,15 +82,15 @@ sudo apt-get install clang libicu-dev libatomic1 build-essential pkg-config
 
 ### Download Toolchain
 
-This guide will install Swift 5.1.3. Visit the [Swift Downloads](https://swift.org/download/#releases) page for a link to latest release. Copy the download link for Ubuntu 18.04.
+This guide will install Swift 5.2.0. Visit the [Swift Downloads](https://swift.org/download/#releases) page for a link to latest release. Copy the download link for Ubuntu 18.04.
 
 ![Download Swift](../images/swift-download-ubuntu-18-copy-link.png)
 
 Download and decompress the Swift toolchain.
 
 ```sh
-wget https://swift.org/builds/swift-5.1.3-release/ubuntu1804/swift-5.1.3-RELEASE/swift-5.1.3-RELEASE-ubuntu18.04.tar.gz
-tar xzf swift-5.1.3-RELEASE-ubuntu18.04.tar.gz
+wget https://swift.org/builds/swift-5.2.0-release/ubuntu1804/swift-5.2.0-RELEASE/swift-5.2.0-RELEASE-ubuntu18.04.tar.gz
+tar xzf swift-5.2.0-RELEASE-ubuntu18.04.tar.gz
 ```
 
 !!! note
@@ -102,13 +102,13 @@ Move Swift somewhere easy to acess. This guide will use `/swift` with each compi
 
 ```sh
 sudo mkdir /swift
-sudo mv swift-5.1.3-RELEASE-ubuntu18.04 /swift/5.1.3
+sudo mv swift-5.2.0-RELEASE-ubuntu18.04 /swift/5.2.0
 ```
 
 Add Swift to `/usr/bin` so it can be executed by `vapor` and `root`.
 
 ```sh
-sudo ln -s /swift/5.1.3/usr/bin/swift /usr/bin/swift
+sudo ln -s /swift/5.2.0/usr/bin/swift /usr/bin/swift
 ```
 
 Verify that Swift was installed correctly.

--- a/4.0/docs/fluent/config.md
+++ b/4.0/docs/fluent/config.md
@@ -40,7 +40,7 @@ PostgreSQL is an open source, standards compliant SQL database. It is easily con
 To use PostgreSQL, add the following dependencies to your package.
 
 ```swift
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(
@@ -88,7 +88,7 @@ SQLite is an open source, embedded SQL database. Its simplistic nature makes it 
 To use SQLite, add the following dependencies to your package.
 
 ```swift
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(
@@ -138,7 +138,7 @@ MySQL is a popular open source SQL database. It is available on many cloud hosti
 To use MySQL, add the following dependencies to your package.
 
 ```swift
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(

--- a/4.0/docs/install/macos.md
+++ b/4.0/docs/install/macos.md
@@ -1,10 +1,13 @@
 # Install on macOS
 
-To use Vapor on macOS, you will need Swift 5.1 or greater. Swift and all of its dependencies come bundled with Xcode.
+To use Vapor on macOS, you will need Swift 5.2 or greater. Swift and all of its dependencies come bundled with Xcode.
 
 ## Install Xcode
 
 Install [Xcode 11 or greater](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) from the Mac App Store.
+
+!!! warning
+	At the time of writing, Xcode 11.4 which includes Swift 5.2 is in beta. You can download it from the [developer portal](https://developer.apple.com/download/) or download the latest Swift 5.2 toolchain from [Swift.org](https://swift.org/download/). 
 
 ![Xcode 11](https://user-images.githubusercontent.com/1342803/66688324-2396bc80-ec54-11e9-8b96-bd8b29d0ce7c.jpg)
 
@@ -19,11 +22,11 @@ swift --version
 You should see Swift's version information printed.
 
 ```sh
-Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)
+Apple Swift version 5.2 (swiftlang-1100.0.270.13 clang-1100.0.33.7)
 Target: x86_64-apple-darwin19.0.0
 ```
 
-Vapor 4 requires Swift 5.1 or greater.
+Vapor 4 requires Swift 5.2 or greater.
 
 ## Install Toolbox
 

--- a/4.0/docs/install/ubuntu.md
+++ b/4.0/docs/install/ubuntu.md
@@ -1,16 +1,15 @@
 # Install on Ubuntu
 
-To use Vapor on Ubuntu, you will need Swift 5.1 or greater. This can be installed using the toolchains available on [Swift.org](https://swift.org/download/)
+To use Vapor on Ubuntu, you will need Swift 5.2 or greater. This can be installed using the toolchains available on [Swift.org](https://swift.org/download/)
 
 ## Supported Versions
 
-Vapor supports the same versions of Ubuntu that Swift supports.
+Vapor supports the same versions of Ubuntu that Swift 5.2 supports.
 
 | Version | Codename          |
 |---------|-------------------|
 | 18.04   | Bionic Beaver     |
 | 16.04   | Xenial Xerus      |
-| 14.04   | Trusty Tahr       |
 
 ## Installation
 

--- a/4.0/docs/spm.md
+++ b/4.0/docs/spm.md
@@ -11,7 +11,7 @@ The first place SPM looks in your project is the package manifest. This should a
 Take a look at this example Package manifest.
 
 ```swift
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
Updates Vapor 4 docs to require Swift 5.2.