### PR TITLE
Remove Bcrypt hash function argument

### DIFF
--- a/4.0/docs/fluent/authentication.md
+++ b/4.0/docs/fluent/authentication.md
@@ -117,7 +117,7 @@ app.post("users") { req -> EventLoopFuture<User> in
     let user = try User(
         name: create.name,
         email: create.email,
-        passwordHash: Bcrypt.hash(password: create.password)
+        passwordHash: Bcrypt.hash(create.password)
     )
     return user.save(on: req.db)
         .map { user }


### PR DESCRIPTION
Fixed typo which specified the argument `password` in 

```
func hash(_ plaintext: String, cost: Int = 12) throws -> String
```