### PR TITLE
Specified a return type

### DIFF
--- a/4.0/docs/logging.md
+++ b/4.0/docs/logging.md
@@ -11,7 +11,7 @@ Instances of `Logger` are used for outputting log messages. Vapor provides a few
 Each incoming `Request` has a unique logger that you should use for any logs specific to that request.
 
 ```swift
-app.get("hello") { req in
+app.get("hello") { req -> String in
     req.logger.info("Hello, logs!")
     return "Hello, world!"
 }


### PR DESCRIPTION
Not specifying a return type is only possible on closures when it's a single line function. Without this change the code doesn't build an returns the following error: `Generic parameter 'Response' could not be inferred`