### PR TITLE
Use https URL for the docs link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Documentation
 
-Read the docs at [docs.vapor.codes](http://docs.vapor.codes)
+Read the docs at [docs.vapor.codes](https://docs.vapor.codes)


### PR DESCRIPTION
HTTP URLs are marked as insecure in most browsers these days.