### PR TITLE
Fix typo in CreateStarTag migration

### DIFF
--- a/4.0/docs/fluent/overview.md
+++ b/4.0/docs/fluent/overview.md
@@ -635,8 +635,8 @@ struct CreateStarTag: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         database.schema("star_tag")
             .id()
-            .field("star_id", .uuid, .required, .references("star", "id"))
-            .field("tag_id", .uuid, .required, .references("star", "id"))
+            .field("star_id", .uuid, .required, .references("stars", "id"))
+            .field("tag_id", .uuid, .required, .references("stars", "id"))
             .create()
     }
 

--- a/4.0/docs/fluent/overview.md
+++ b/4.0/docs/fluent/overview.md
@@ -636,7 +636,7 @@ struct CreateStarTag: Migration {
         database.schema("star_tag")
             .id()
             .field("star_id", .uuid, .required, .references("stars", "id"))
-            .field("tag_id", .uuid, .required, .references("stars", "id"))
+            .field("tag_id", .uuid, .required, .references("tags", "id"))
             .create()
     }
 


### PR DESCRIPTION
A bigger change would be to change the examples to use the static schema property of the model.  That should probably be done for the whole file though.