### PR TITLE
Corrects Nginx `try_files` example

### DIFF
--- a/4.0/docs/deploy/nginx.md
+++ b/4.0/docs/deploy/nginx.md
@@ -106,8 +106,10 @@ server {
 	...
 
 	# Serve all public/static files via nginx and then fallback to Vapor for the rest
-    try_files $uri @proxy;
-	
+	location / {
+		try_files $uri @proxy;
+	}
+
 	location @proxy {
 		...
 	}


### PR DESCRIPTION
Fixes #467 

The `try_files` directive should be within a `location` block, and is
so in all example uses of `try_files` in the nginx documentation at
http://nginx.org/en/docs/http/ngx_http_core_module.html#try_files.

It is however curious that the nginx docs seem to indicate that
`try_files` can operate in either the server or location context, but
no examples show that use case.

Signed-off-by: zach wick <zach@zachwick.com>