### PR TITLE
Corrects the description of the 'trace' level of logging

### DIFF
--- a/4.0/docs/logging.md
+++ b/4.0/docs/logging.md
@@ -52,7 +52,7 @@ SwiftLog supports several different logging levels.
 
 |name|description|
 |-|-|
-|trace|Appropriate for messages that contain information only when debugging a program.|
+|trace|Appropriate for messages that contain information normally of use only when tracing the execution of a program.|
 |debug|Appropriate for messages that contain information normally of use only when debugging a program.|
 |info|Appropriate for informational messages.|
 |notice|Appropriate for conditions that are not error conditions, but that may require special handling.|


### PR DESCRIPTION
Fixes #463

The 'trace' level of logging is the least severe level of logging in SwiftLog
and should be used only when tracing the execution flow of a program during
debugging.

This description of the 'trace' level of logging, is verbatim the description
of the 'trace' level in the SwiftLog documentation at
https://github.com/apple/swift-log/blob/74d7b91ceebc85daf387ebb206003f78813f71aa/Sources/Logging/Logging.swift#L327
and I will file a bug report and PR there in the upstream project.

Signed-off-by: zach wick <zach@zachwick.com>