### PR TITLE
Add QueuesFluentDriver as community driver

### DIFF
--- a/4.0/docs/queues.md
+++ b/4.0/docs/queues.md
@@ -24,6 +24,7 @@ Queues currently has one officially supported driver which interfaces with the m
 - [QueuesRedisDriver](https://github.com/vapor/queues-redis-driver)
 
 Queues also has community-based drivers:
+- [QueuesFluentDriver](https://github.com/m-barthelemy/vapor-queues-fluent-driver)
 - [JobsPostgresqlDriver](https://github.com/vapor-community/jobs-postgresql-driver)
 
 !!! tip

--- a/4.0/docs/queues.md
+++ b/4.0/docs/queues.md
@@ -24,6 +24,7 @@ Queues currently has one officially supported driver which interfaces with the m
 - [QueuesRedisDriver](https://github.com/vapor/queues-redis-driver)
 
 Queues also has community-based drivers:
+
 - [QueuesFluentDriver](https://github.com/m-barthelemy/vapor-queues-fluent-driver)
 - [JobsPostgresqlDriver](https://github.com/vapor-community/jobs-postgresql-driver)
 


### PR DESCRIPTION
This PR adds my QueuesFluentDriver to the list of community drivers for Vapor Queues.