### PR TITLE
Docs 4.0: Corrects ngnix example config to use 'location /' instead of 'location @proxy'

### DIFF
--- a/4.0/docs/deploy/nginx.md
+++ b/4.0/docs/deploy/nginx.md
@@ -82,7 +82,7 @@ server {
 
     root /home/vapor/Hello/Public/;
 
-    location @proxy {
+    location / {
         proxy_pass http://127.0.0.1:8080;
         proxy_pass_header Server;
         proxy_set_header Host $host;


### PR DESCRIPTION
The `@proxy` location was not defined, so the the server returned an `403 Forbidden` error. 
Use `location /` instead.