### PR TITLE
Docs 4.0: Updated Mongodb package dependency

### DIFF
--- a/4.0/docs/fluent/overview.md
+++ b/4.0/docs/fluent/overview.md
@@ -142,7 +142,7 @@ MongoDB is a popular schemaless NoSQL database designed for programmers. The dri
 To use MongoDB, add the following dependencies to your package.
 
 ```swift
-.package(name: "FluentMongoDriver", url: "https://github.com/vapor/fluent-mongo-driver.git", from: "1.0.0"),
+.package(url: "https://github.com/vapor/fluent-mongo-driver.git", from: "1.0.0-rc"),
 ```
 
 ```swift


### PR DESCRIPTION
The existing sample code to add MongoDB's driver didn't work because of an extra name and mismatched version on the .product().

```
Error: Could not generate Xcode project: 'hello' /Users/.../.../hello: error: declared name 'FluentMongoDriver' for package dependency 'https://github.com/vapor/fluent-mongo-driver.git' does not match the actual package name 'fluent-mongo-driver'
```

```
error: because no versions of fluent-mongo-driver match the requirement 1.0.0..<2.0.0 and root depends on fluent-mongo-driver 1.0.0..<2.0.0, version solving failed.
```