### PR TITLE
Provide `ResponseEncodable` example in content.md

### DIFF
--- a/4.0/docs/content.md
+++ b/4.0/docs/content.md
@@ -243,7 +243,7 @@ extension HTML: ResponseEncodable {
 }
 ```
 
-Note that this allows customising the `Content-Type` header. See [`HTTPHeaders` reference](http://api.vapor.codes/vapor/4.0.0-alpha.1/Vapor/Extensions/HTTPHeaders.html) for more details.
+Note that this allows customising the `Content-Type` header. See [`HTTPHeaders` reference](https://api.vapor.codes/vapor/4.0.0-alpha.1/Vapor/Extensions/HTTPHeaders.html) for more details.
 
 You can then use `HTML` as a response type in your routes:
 


### PR DESCRIPTION
I wasn't able to find any documentation on how to tweak `Content-Type` header for custom response types. An example of this is added to `content.md`, which seems to fit this topic the most.