### PR TITLE
Update hello-world.md

### DIFF
--- a/4.0/docs/hello-world.md
+++ b/4.0/docs/hello-world.md
@@ -25,11 +25,17 @@ cd hello
 open Package.swift
 ```
 
+## Xcode Dependencies
+
+You should now have Xcode open. It will automatically begin downloading Swift Package Manager dependencies.
+
+At the top of the window, to the right of the Play and Stop buttons, click on your project name to select the project's Scheme, and select an appropriate run target—most likely, "My Mac".
+
 ## Build & Run
 
-You should now have Xcode open. Click the play button to build and run your project.
+Once the Swift Package Manager dependencies have finished downloading, click the play button to build and run your project.
 
-You should see the terminal pop up at the bottom of the screen.
+You should see the Console pop up at the bottom of the Xcode window.
 
 ```sh
 [ INFO ] Server starting on http://127.0.0.1:8080


### PR DESCRIPTION
The previous instructions suggested that you could continue with "Build & Run" as soon as Xcode opens, but this is not correct and the Play button is at this point greyed out as unavailable, as is selecting "Build and Run" from the menu, as dependencies are still being downloaded. This could lead users inexperienced with Xcode to think they have done something wrong when they just need to wait a minute or so. This seems likely the cause of at least one comment I saw on Vapor discussion somewhere today when searching for a new user guide (sorry, location lost) where the new user stated that Step 2 of these instructions did not work.

This change also correctly identifies the expected output will be in the Xcode console, and not in the "terminal".