### PR TITLE
update docs for toolbox release

### DIFF
--- a/4.0/docs/commands.md
+++ b/4.0/docs/commands.md
@@ -7,13 +7,13 @@ Vapor's Command API allows you to build custom command-line functions and intera
 You can learn more about Vapor's default commands using the `--help` option. 
 
 ```sh
-vapor-beta run --help
+vapor run --help
 ```
 
 You can use `--help` on a specific command to see what arguments and options it accepts.
 
 ```sh
-vapor-beta run serve --help
+vapor run serve --help
 ```
 
 ### Xcode
@@ -74,7 +74,7 @@ context.console.print("Hello, \(name) 👋")
 Test your command by running:
 
 ```sh
-vapor-beta run hello
+vapor run hello
 ```
 
 ### Cowsay
@@ -125,5 +125,5 @@ app.commands.use(Cowsay(), as: "cowsay")
 ```
 
 ```sh
-vapor-beta run cowsay sup --eyes ^^ --tongue "U "
+vapor run cowsay sup --eyes ^^ --tongue "U "
 ```

--- a/4.0/docs/deploy/docker.md
+++ b/4.0/docs/deploy/docker.md
@@ -25,7 +25,7 @@ You will need to install Docker for your developer environment. You can find inf
 We suggest using the Vapor template as a starting place. If you already have an App, build the template as described below into a new folder as a point of reference while dockerizing your existing app -- you can copy key resources from the template to your app and tweak them slightly as a jumping off point.
 
 1. Install or build the Vapor Toolbox ([macOS](../install/macos.md#install-toolbox), [Linux](../install/linux.md#install-toolbox)).
-2. Create a new Vapor App with `vapor-beta new my-dockerized-app` and walk through the prompts to enable or disable relevant features. Your answers to these prompts will affect how the Docker resource files are generated.
+2. Create a new Vapor App with `vapor new my-dockerized-app` and walk through the prompts to enable or disable relevant features. Your answers to these prompts will affect how the Docker resource files are generated.
 
 ## Docker Resources
 
@@ -88,7 +88,7 @@ A Docker Compose file defines the way Docker should build out multiple services 
 !!! note
     If you ultimately plan to use Kubernetes to orchestrate your app, the Docker Compose file is not directly relevant. However, Kubernetes manifest files are similar conceptually and there are even projects out there aimed at [porting Docker Compose files](https://kubernetes.io/docs/tasks/configure-pod-container/translate-compose-kubernetes/) to Kubernetes manifests.
 
-The Docker Compose file in your new Vapor App will define services for running your app, running migrations or reverting them, and running a database as your app's persistence layer. The exact definitions will vary depending on which database you chose to use when you ran `vapor-beta new`.
+The Docker Compose file in your new Vapor App will define services for running your app, running migrations or reverting them, and running a database as your app's persistence layer. The exact definitions will vary depending on which database you chose to use when you ran `vapor new`.
 
 Note that your Docker Compose file has some shared environment variables near the top.
 ```docker

--- a/4.0/docs/environment.md
+++ b/4.0/docs/environment.md
@@ -18,7 +18,7 @@ default:
 By default, your app will run in the `development` environment. You can change this by passing the `--env` (`-e`) flag during app boot.
 
 ```swift
-vapor-beta run serve --env production
+vapor run serve --env production
 ```
 
 Vapor includes the following environments:
@@ -35,7 +35,7 @@ Vapor includes the following environments:
 You can pass either the full or short name to the `--env` (`-e`) flag.
 
 ```swift
-vapor-beta run serve -e prod
+vapor run serve -e prod
 ```
 
 ## Process Variables
@@ -58,7 +58,7 @@ When running your app in the terminal, you can set environment variables using `
 
 ```sh
 export FOO=BAR
-vapor-beta run serve
+vapor run serve
 ```
 
 When running your app in Xcode, you can set environment variables by editing the `Run` scheme.

--- a/4.0/docs/fluent/migration.md
+++ b/4.0/docs/fluent/migration.md
@@ -43,7 +43,7 @@ Migrations should be listed in order of dependency. For example, if `MigrationB`
 To migrate your database, run the `migrate` command.
 
 ```sh
-vapor-beta run migrate
+vapor run migrate
 ```
 
 You can also run this [command through Xcode](../commands.md#xcode). The migrate command will check the database to see if any new migrations have been registered since it was last run. If there are new migrations, it will ask for a confirmation before running them.
@@ -53,7 +53,7 @@ You can also run this [command through Xcode](../commands.md#xcode). The migrate
 To undo a migration on your database, run `migrate` with the `--revert` flag.
 
 ```sh
-vapor-beta run migrate --revert
+vapor run migrate --revert
 ```
 
 The command will check the database to see which batch of migrations was last run and ask for a confirmation before reverting them.
@@ -63,7 +63,7 @@ The command will check the database to see which batch of migrations was last ru
 If you would like migrations to run automatically before running other commands, you can pass the `--auto-migrate` flag. 
 
 ```sh
-vapor-beta run serve --auto-migrate
+vapor run serve --auto-migrate
 ```
 
 You can also do this programatically. 

--- a/4.0/docs/fluent/overview.md
+++ b/4.0/docs/fluent/overview.md
@@ -14,7 +14,7 @@ If you have an existing project that you want to add Fluent to, you will need to
 - One (or more) Fluent driver(s) of your choice
 
 ```swift
-.package(url: "https://github.com/vapor/fluent.git", from: "4.0.0-beta"),
+.package(url: "https://github.com/vapor/fluent.git", from: "4.0.0"),
 .package(url: "https://github.com/vapor/fluent-<db>-driver.git", from: <version>),
 ```
 
@@ -48,7 +48,7 @@ PostgreSQL is an open source, standards compliant SQL database. It is easily con
 To use PostgreSQL, add the following dependencies to your package.
 
 ```swift
-.package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.0.0-beta")
+.package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.0.0")
 ```
 
 ```swift
@@ -291,7 +291,7 @@ To run migrations, call `vapor run migrate` from the command line or add `migrat
 
 
 ```
-$ vapor-beta run migrate
+$ vapor run migrate
 Migrate Command: Prepare
 The following migration(s) will be prepared:
 + CreateGalaxy on default

--- a/4.0/docs/hello-world.md
+++ b/4.0/docs/hello-world.md
@@ -12,7 +12,7 @@ If you have not yet installed Swift or Vapor Toolbox, check out the install sect
 The first step is to create a new Vapor project on your computer. Open up your terminal and use Toolbox's new project command. This will create a new folder in the current directory containing the project.
 
 ```sh
-vapor-beta new hello -n
+vapor new hello -n
 ```
 
 !!! tip

--- a/4.0/docs/install/macos.md
+++ b/4.0/docs/install/macos.md
@@ -32,13 +32,13 @@ Now that you have Swift installed, let us install the [Vapor Toolbox](https://gi
 Toolbox is distributed via Homebrew. If you do not have Homebrew yet, visit <a href="https://brew.sh" target="_blank">brew.sh</a> for install instructions.
 
 ```sh
-brew install vapor/tap/vapor-beta
+brew install vapor/tap/vapor
 ```
 
 Double check to ensure that the installation was successful by printing help.
 
 ```sh
-vapor-beta --help
+vapor --help
 ```
 
 You should see a list of available commands.

--- a/4.0/docs/logging.md
+++ b/4.0/docs/logging.md
@@ -71,14 +71,14 @@ Regardless of environment mode, you can override the logging level to increase o
 The first method is to pass the optional `--log` flag when booting your application.
 
 ```sh
-vapor-beta run serve --log debug
+vapor run serve --log debug
 ```
 
 The second method is to set the `LOG_LEVEL` environment variable.
 
 ```sh
 export LOG_LEVEL=debug
-vapor-beta run serve
+vapor run serve
 ```
 
 Both of these can be done in Xcode by editing the `Run` scheme.

--- a/4.0/docs/server.md
+++ b/4.0/docs/server.md
@@ -26,7 +26,7 @@ The server configuration's hostname can be overridden by passing the `--hostname
 
 ```sh
 # Override configured hostname.
-vapor-beta run serve --hostname dev.local
+vapor run serve --hostname dev.local
 ```
 
 ### Port
@@ -46,7 +46,7 @@ The server configuration's port can be overridden by passing the `--port` (`-p`)
 
 ```sh
 # Override configured port.
-vapor-beta run serve --port 1337
+vapor run serve --port 1337
 ```
 
 ### Backlog
@@ -164,7 +164,7 @@ app.http.server.configuration.serverName = "vapor"
 To start up Vapor's server, use the `serve` command. This command will run by default if no other commands are specified. 
 
 ```swift
-vapor-beta run serve
+vapor run serve
 ```
 
 The `serve` command accepts the following parameters:
@@ -176,10 +176,10 @@ The `serve` command accepts the following parameters:
 An example using the `--bind` (`-b`) flag:
 
 ```swift
-vapor-beta run serve -b 0.0.0.0:80
+vapor run serve -b 0.0.0.0:80
 ```
 
-Use `vapor-beta run serve --help` for more information.
+Use `vapor run serve --help` for more information.
 
 The `serve` command will listen for `SIGTERM` and `SIGINT` to gracefully shutdown the server. Use `ctrl+c` (`^c`) to send a `SIGINT` signal. When the log level is set to `debug` or lower, information about the status of graceful shutdown will be logged.
 

--- a/4.0/docs/upgrading.md
+++ b/4.0/docs/upgrading.md
@@ -99,7 +99,7 @@ Vapor may add additional supported platforms in the future. Your package may sup
 
 Vapor 4 utilizies Xcode 11's native SPM support. This means you will no longer need to generate `.xcodeproj` files. Opening your project's folder in Xcode will automatically recognize SPM and pull in dependencies. 
 
-You can open your project natively in Xcode using `vapor-beta xcode` or `open Package.swift`. 
+You can open your project natively in Xcode using `vapor xcode` or `open Package.swift`. 
 
 Once you've updated Package.swift, you may need to close Xcode and clear the following folders from the root directory:
 


### PR DESCRIPTION
Updates docs to use `vapor` CLI instead of `vapor-beta`. 