### PR TITLE
Updated field constraint example

### DIFF
--- a/4.0/docs/fluent/schema.md
+++ b/4.0/docs/fluent/schema.md
@@ -58,7 +58,7 @@ Fields can be added when creating or updating a schema.
 
 ```swift
 // Adds a new field
-.field("name", .string, .unique)
+.field("name", .string, .required)
 ```
 
 The first parameter is the name of the field. This should match the key used on the associated model property. The second parameter is the field's [data type](#data-type). Finally, zero or more [constraints](#field-constraint) can be added. 


### PR DESCRIPTION
The .unique is not a valid field constraint. I've updated the docs to correct this minor mistake.