### PR TITLE
Added mutating keyword to afterDecode and beforeEncode hooks

### DIFF
--- a/4.0/docs/content.md
+++ b/4.0/docs/content.md
@@ -126,7 +126,7 @@ Vapor will automatically call `beforeDecode` and `afterDecode` on a `Content` ty
 
 ```swift
 // Runs after this Content is decoded.
-func afterDecode() throws {
+mutating func afterDecode() throws {
     // Name may not be passed in, but if it is, then it can't be an empty string.
     self.name = self.name?.trimmingCharacters(in: .whitespacesAndNewlines)
     if let name = self.name, name.isEmpty {
@@ -135,7 +135,7 @@ func afterDecode() throws {
 }
 
 // Runs before this Content is encoded.
-func beforeEncode() throws {
+mutating func beforeEncode() throws {
     // Have to *always* pass a name back, and it can't be an empty string.
     guard 
         let name = self.name?.trimmingCharacters(in: .whitespacesAndNewlines), 

--- a/4.0/docs/content.md
+++ b/4.0/docs/content.md
@@ -125,7 +125,7 @@ let name: String? = req.query["name"]
 Vapor will automatically call `beforeDecode` and `afterDecode` on a `Content` type. Default implementations are provided which do nothing, but you can use these methods to run custom logic.
 
 ```swift
-// Runs after this Content is decoded.
+// Runs after this Content is decoded. `mutating` is only required for structs, not classes.
 mutating func afterDecode() throws {
     // Name may not be passed in, but if it is, then it can't be an empty string.
     self.name = self.name?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -134,7 +134,7 @@ mutating func afterDecode() throws {
     }
 }
 
-// Runs before this Content is encoded.
+// Runs before this Content is encoded. `mutating` is only required for structs, not classes.
 mutating func beforeEncode() throws {
     // Have to *always* pass a name back, and it can't be an empty string.
     guard 


### PR DESCRIPTION
The mutating keyword is required, as both functions assign a new value to `self.name`.
The current code example results in the following error: **Cannot assign to property: 'self' is immutable**