### PR TITLE
Fix broken link in content.md

### DIFF
--- a/4.0/docs/content.md
+++ b/4.0/docs/content.md
@@ -243,7 +243,7 @@ extension HTML: ResponseEncodable {
 }
 ```
 
-Note that this allows customizing the `Content-Type` header. See [`HTTPHeaders` reference](https://api.vapor.codes/vapor/4.0.0-alpha.1/Vapor/Extensions/HTTPHeaders.html) for more details.
+Note that this allows customizing the `Content-Type` header. See [`HTTPHeaders` reference](https://api.vapor.codes/vapor/master/Vapor/) for more details.
 
 You can then use `HTML` as a response type in your routes:
 

--- a/4.0/docs/content.md
+++ b/4.0/docs/content.md
@@ -243,7 +243,7 @@ extension HTML: ResponseEncodable {
 }
 ```
 
-Note that this allows customising the `Content-Type` header. See [`HTTPHeaders` reference](https://api.vapor.codes/vapor/4.0.0-alpha.1/Vapor/Extensions/HTTPHeaders.html) for more details.
+Note that this allows customizing the `Content-Type` header. See [`HTTPHeaders` reference](https://api.vapor.codes/vapor/4.0.0-alpha.1/Vapor/Extensions/HTTPHeaders.html) for more details.
 
 You can then use `HTML` as a response type in your routes:
 


### PR DESCRIPTION
For some reason `HTTPHeaders` API docs are no longer generated, at least the link could redirect to the main page.

The spelling is also changed to American English.