### PR TITLE
Fix an invalid example password in Authentication

### DIFF
--- a/4.0/docs/authentication.md
+++ b/4.0/docs/authentication.md
@@ -351,8 +351,8 @@ Content-Type: application/json
 {
     "name": "Vapor",
     "email": "test@vapor.codes",
-    "password": "secret",
-    "confirmPassword": "secret"
+    "password": "secret42",
+    "confirmPassword": "secret42"
 }
 ```
 
@@ -393,10 +393,10 @@ Test that this route works by sending the following request.
 
 ```http
 POST /login HTTP/1.1
-Authorization: Basic dGVzdEB2YXBvci5jb2RlczpzZWNyZXQ=
+Authorization: Basic dGVzdEB2YXBvci5jb2RlczpzZWNyZXQ0Mg=
 ```
 
-This request passes the username `test@vapor.codes` and password `secret` via the Basic authentication header. You should see the previously created user returned.
+This request passes the username `test@vapor.codes` and password `secret42` via the Basic authentication header. You should see the previously created user returned.
 
 While you could theoretically use Basic authentication to protect all of your endpoints, it's recommended to use a separate token instead. This minimizes how often you must send the user's sensitive password over the Internet. It also makes authentication much faster since you only need to perform password hashing during login.
 


### PR DESCRIPTION
The example in Authentication -> Fluent first establishes code that checks wether a user’s password is at least 8 characters long, and then uses a 6 character password in the example. This is not a huge problem, but it might present a stumbling block for readers who didn’t pay close attention to the code. 

I made the example password longer by two characters, to make sure the example code executes correctly.

(Alternatively I could also change the checker function to require only 6 characters, this would also make the code correct)