### PR TITLE
Added small tip regarding query params

### DIFF
--- a/4.0/docs/routing.md
+++ b/4.0/docs/routing.md
@@ -212,7 +212,7 @@ app.get("hello", ":name") { req -> String in
     We can be sure that `req.parameters.get` will never return `nil` here since our route path includes `:name`. However, if you are accessing route parameters in middleware or in code triggered by multiple routes, you will want to handle the possibility of `nil`.
 
 !!! tip
-    If you want to get params like `/hello/?name=foo` you will need to use Vapor's Content APIs to handle URL encoded data in the URL's query string. Example `let name: String? = req.query["name"]`. See [`Content` reference](https://docs.vapor.codes/4.0/content/) for more details.
+    If you want to retrieve URL query params, e.g. `/hello/?name=foo` you need to use Vapor's Content APIs to handle URL encoded data in the URL's query string. See [`Content` reference](https://docs.vapor.codes/4.0/content/) for more details.
 
 `req.parameters.get` also supports casting the parameter to `LosslessStringConvertible` types automatically. 
 

--- a/4.0/docs/routing.md
+++ b/4.0/docs/routing.md
@@ -211,6 +211,8 @@ app.get("hello", ":name") { req -> String in
 !!! tip
     We can be sure that `req.parameters.get` will never return `nil` here since our route path includes `:name`. However, if you are accessing route parameters in middleware or in code triggered by multiple routes, you will want to handle the possibility of `nil`.
 
+!!! tip
+    If you want to get params like `/hello/?name=foo` you will need to use Vapor's Content APIs to handle URL encoded data in the URL's query string. Example `let name: String? = req.query["name"]`. See [`Content` reference](https://docs.vapor.codes/4.0/content/) for more details.
 
 `req.parameters.get` also supports casting the parameter to `LosslessStringConvertible` types automatically. 
 


### PR DESCRIPTION
To clarify a little bit between the difference of `req.params.get` and `req.query`.

!!! tip
    If you want to get params like `/hello/?name=foo` you will need to use Vapor's Content APIs to handle URL encoded data in the URL's query string. Example `let name: String? = req.query["name"]`. See [`Content` reference](https://docs.vapor.codes/4.0/content/) for more details.