### PR TITLE
Bumped fluent-sqlite-driver version to 4.0.0 in Fluent Overview

### DIFF
--- a/4.0/docs/fluent/overview.md
+++ b/4.0/docs/fluent/overview.md
@@ -77,7 +77,7 @@ SQLite is an open source, embedded SQL database. Its simplistic nature makes it 
 To use SQLite, add the following dependencies to your package.
 
 ```swift
-.package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.0.0-beta")
+.package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.0.0")
 ```
 
 ```swift


### PR DESCRIPTION
I was going through this and copy+pasted, then noticed it still had the `-beta` tag. Wanted to bump this just in case anyone else makes the same mistake!

I bumped it to `4.0.0` after checking the [releases for vapor/fluent-sqlite-driver](https://github.com/vapor/fluent-sqlite-driver/releases). I see there's also a `4.0.1`, but I feel like `4.0.0` was more appropriate.