### PR TITLE
Added example of how to configure Postgres database with unverified TLS for Heroku deployment

### DIFF
--- a/4.0/docs/deploy/heroku.md
+++ b/4.0/docs/deploy/heroku.md
@@ -206,7 +206,18 @@ if let databaseURL = Environment.get("DATABASE_URL") {
 }
 ```
 
-Unverified TLS is required if you are using Heroku Postgres's standard plan.
+Unverified TLS is required if you are using Heroku Postgres's standard plan:
+
+```swift
+if let databaseURL = Environment.get("DATABASE_URL"), var postgresConfig = PostgresConfiguration(url: databaseURL) {
+    postgresConfig.tlsConfiguration = .forClient(certificateVerification: .none)
+    app.databases.use(.postgres(
+        configuration: postgresConfig
+    ), as: .psql)
+} else {
+    // ...
+}
+```
 
 Don't forget to commit these changes
 


### PR DESCRIPTION
I noticed the [3.0 docs](https://docs.vapor.codes/3.0/deploy/heroku/#configure-the-database) showed how to configure unverified TLS for your Postgres database when deploying to Heroku. It took me a little while to figure out the right way to do this in Vapor 4 so I figured it might be worthwhile to include it in the 4.0 docs.