### PR TITLE
SQLite foreign key violation tip

### DIFF
--- a/4.0/docs/fluent/overview.md
+++ b/4.0/docs/fluent/overview.md
@@ -106,6 +106,9 @@ app.migrations.add(CreateTodo())
 try app.autoMigrate().wait()
 ```
 
+!!! tip
+    The SQLite configuration automatically enables foreign key constraints on all created connections, but does not alter foreign key configurations in the database itself. Deleting records in a database directly, might violate foreign key constraints and triggers.
+
 #### MySQL
 
 MySQL is a popular open source SQL database. It is available on many cloud hosting providers. This driver also supports MariaDB.


### PR DESCRIPTION
I ran into an issue where `PRAGMA foreign_keys = ON` was required on the database itself. I was unaware of this, as it worked for Vapor. I added a tip containing problems that can occur when querying the database directly.