### PR TITLE
Add example to use MySQL in local without SSL

### DIFF
--- a/4.0/docs/fluent/overview.md
+++ b/4.0/docs/fluent/overview.md
@@ -150,6 +150,9 @@ app.databases.use(.mysql(
 ), as: .mysql)
 ```
 
+!!! warning
+    Do not disable certificate verification in production. You should provide a certificate to the `TLSConfiguration` to verify against. 
+
 #### MongoDB
 
 MongoDB is a popular schemaless NoSQL database designed for programmers. The driver supports all cloud hosting providers and self-hosted installations from version 3.4 and up.

--- a/4.0/docs/fluent/overview.md
+++ b/4.0/docs/fluent/overview.md
@@ -138,7 +138,7 @@ You can also parse the credentials from a database connection string.
 try app.databases.use(.mysql(url: "<connection string>"), as: .mysql)
 ```
 
-To configure a local connection without SSL certificate involved, you should disable certificate verification.
+To configure a local connection without SSL certificate involved, you should disable certificate verification. You might need to do this for example if connecting to a MySQL 8 database in Docker.
 
 ```swift
 app.databases.use(.mysql(

--- a/4.0/docs/fluent/overview.md
+++ b/4.0/docs/fluent/overview.md
@@ -138,6 +138,18 @@ You can also parse the credentials from a database connection string.
 try app.databases.use(.mysql(url: "<connection string>"), as: .mysql)
 ```
 
+To configure a local connection without SSL certificate involved, you should disable certificate verification.
+
+```swift
+app.databases.use(.mysql(
+    hostname: "localhost", 
+    username: "vapor", 
+    password: "vapor", 
+    database: "vapor", 
+    tlsConfiguration: .forClient(certificateVerification: .none)
+), as: .mysql)
+```
+
 #### MongoDB
 
 MongoDB is a popular schemaless NoSQL database designed for programmers. The driver supports all cloud hosting providers and self-hosted installations from version 3.4 and up.


### PR DESCRIPTION
Faced this issue when starting a new project, found the answer [here](https://forums.swift.org/t/fluent-connect-mysql-8-failure-how-to-solve/35939/14) and applied it [here](https://github.com/Lloople/where-is-my-stuff/blob/master/Sources/App/configure.swift#L21). 

It's working as expected so I think for new users would be useful to have this information directly in vapor docs 👍