### PR TITLE
Fix the variable name in sample code.

### DIFF
--- a/4.0/docs/authentication.md
+++ b/4.0/docs/authentication.md
@@ -597,7 +597,7 @@ Next, let's create a simple bearer authenticator to perform the initial authenti
 struct UserBearerAuthenticator: BearerAuthenticator {
     func authenticate(bearer: BearerAuthorization, for request: Request) -> EventLoopFuture<Void> {
         if bearer.token == "test" {
-            let user = User(name: "hello@vapor.codes")
+            let user = User(email: "hello@vapor.codes")
             request.auth.login(user)
         }
         return request.eventLoop.makeSucceededFuture(())


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
The member variable name should be `email` in this example.
<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
