### PR TITLE
Fix the table name in foreign key sample code.

### DIFF
--- a/4.0/docs/fluent/schema.md
+++ b/4.0/docs/fluent/schema.md
@@ -192,7 +192,7 @@ This same constraint could be added as a top-level constraint using `foreignKey`
 
 ```swift
 // Example of adding a top-level foreign key constraint.
-.foreignKey("star_id", references: "star", "id")
+.foreignKey("star_id", references: "stars", "id")
 ```
 
 Unlike field constraints, top-level constraints can be added in a schema update. They can also be [named](#constraint-name). 
@@ -211,7 +211,7 @@ Below is an example using foreign key actions.
 
 ```swift
 // Example of adding a top-level foreign key constraint.
-.foreignKey("star_id", references: "star", "id", onDelete: .cascade)
+.foreignKey("star_id", references: "stars", "id", onDelete: .cascade)
 ```
 
 !!! warning


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
The correct table name should be `stars` according to the context.
<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
