### PR TITLE
Add Linux Development hint in hello-world.md

### DIFF
--- a/4.0/docs/hello-world.md
+++ b/4.0/docs/hello-world.md
@@ -27,7 +27,7 @@ open Package.swift
 
 ## Linux Development
 
-If you are working on Linux, consider to add an empty file called `LinuxMain.swift` under the `Sources/Tests/` folder. This allows the [Language Server Protocol](https://github.com/apple/sourcekit-lsp) included in your Swift toolchain to works properly, and if you are working on an editor that supports it, you can have a better development experience.
+If you are working on Linux, consider adding an empty file called `LinuxMain.swift` under the `Sources/Tests/` folder. This allows the [Language Server Protocol](https://github.com/apple/sourcekit-lsp) included in your Swift toolchain to works properly, so if you are working on an editor that supports it, you can have a better development experience.
 
 ## Xcode Dependencies
 

--- a/4.0/docs/hello-world.md
+++ b/4.0/docs/hello-world.md
@@ -25,6 +25,10 @@ cd hello
 open Package.swift
 ```
 
+## Linux Development
+
+If you are working on Linux, consider to add an empty file called `LinuxMain.swift` under the `Sources/Tests/` folder. This allows the [Language Server Protocol](https://github.com/apple/sourcekit-lsp) included in your Swift toolchain to works properly, and if you are working on an editor that supports it, you can have a better development experience.
+
 ## Xcode Dependencies
 
 You should now have Xcode open. It will automatically begin downloading Swift Package Manager dependencies.


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
The development experience in Linux, for people that use editors like VSCode with the [SDE extension](https://marketplace.visualstudio.com/items?itemName=vknabel.vscode-swift-development-environment), is terrible without the `LinuxMain.swift` file. 
That's because the Language Server Protocol doesn't work correctly and the result is: every file becomes red, `no such module` error anytime there is an `import Something` statement, and no features like code completion, quick help (hover), jump to definition, ecc...

This section in the doc can help newbies that want to develop their projects under Linux with ease.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
@0xTim