### PR TITLE
Replace the occurrences of "router.get" in sample code with "app.get" for 4.0 docs.

### DIFF
--- a/4.0/docs/async.md
+++ b/4.0/docs/async.md
@@ -272,7 +272,7 @@ futureString.hop(to: otherEventLoop)
 Calling blocking code on an event loop thread can prevent your application from responding to incoming requests in a timely manner. An example of a blocking call would be something like `libc.sleep(_:)`.
 
 ```swift
-router.get("hello") { req in
+app.get("hello") { req in
     /// Puts the event loop's thread to sleep.
     sleep(5)
     
@@ -286,7 +286,7 @@ router.get("hello") { req in
 Make sure to run any blocking work in the background. Use promises to notify the event loop when this work is done in a non-blocking way.
 
 ```swift
-router.get("hello") { req -> EventLoopFuture<String> in
+app.get("hello") { req -> EventLoopFuture<String> in
     /// Dispatch some work to happen on a background thread
     return req.application.threadPool.runIfActive(eventLoop: req.eventLoop) {
         /// Puts the background thread to sleep

--- a/4.0/docs/leaf/getting-started.md
+++ b/4.0/docs/leaf/getting-started.md
@@ -75,7 +75,7 @@ Hello, #(name)!
 Then, register a route (usually done in `routes.swift` or a controller) to render the view.
 
 ```swift
-router.get("hello") { req -> EventLoopFuture<View> in
+app.get("hello") { req -> EventLoopFuture<View> in
     return req.view.render("hello", ["name": "Leaf"])
 }
 ```


### PR DESCRIPTION
I just noticed that there are some places in 4.0 document are using `router.get` in sample code, while that seems to be a legacy pattern in earlier versions. So this change is to replace them with `app.get`.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
