### PR TITLE
Add step to generate LinuxMain.swift for Heroku deployment.

### DIFF
--- a/4.0/docs/deploy/heroku.md
+++ b/4.0/docs/deploy/heroku.md
@@ -134,6 +134,16 @@ echo "web: Run serve --env production" \
   "--hostname 0.0.0.0 --port \$PORT" > Procfile
 ```
 
+### LinuxMain.swift
+
+`LinuxMain.swift` file is required to be in the `Tests` directory when your app is built on Heroku.
+
+Run following command to generate the file:
+
+```bash
+swift test --generate-linuxmain
+```
+
 ### Commit changes
 
 We just added these files, but they're not committed. If we push, heroku will not find them.


### PR DESCRIPTION
Heroku will report the following error in build with the default Vapor scaffolding, we'd better add this step in the doc to overcome this issue.

```
error: missing LinuxMain.swift file in the Tests directory
 !     Push rejected, failed to compile Swift app.
 !     Push failed
```
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
