### PR TITLE
Fixed branch name in GH Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
  deploy:
    name: docs.vapor.codes


### PR DESCRIPTION
The project did not deploy because the branch name was incorrect