### PR TITLE
Updated authentication doc wording

### DIFF
--- a/4.0/docs/authentication.md
+++ b/4.0/docs/authentication.md
@@ -29,7 +29,7 @@ struct User: Authenticatable {
 }
 ```
 
-Each example below will create an authenticator named `UserAuthenticator`. 
+Each example below will use an instance of an authenticator which we created. In these examples, we've called it `UserAuthenticator`.
 
 ### Route
 


### PR DESCRIPTION
The sentence explaining the preceding text regarding the `UserAuthenticator` class was pretty confusing and I feel like this change make it a bit more clear.