### PR TITLE
Fix example response in Content > Query

### DIFF
--- a/4.0/docs/content.md
+++ b/4.0/docs/content.md
@@ -119,7 +119,9 @@ If the query string were omitted, like in the following request, the name "Anony
 
 ```http
 GET /hello HTTP/1.1
-content-length: 0
+content-length: 16
+
+Hello, Anonymous
 ```
 
 ### Single Value


### PR DESCRIPTION
The response now matches its description and the example code that generates it.