### PR TITLE
Add missing `:`s in documentation

### DIFF
--- a/4.0/docs/leaf/overview.md
+++ b/4.0/docs/leaf/overview.md
@@ -115,7 +115,7 @@ You can also use `#elseif` statements:
     Hello new user!
 #elseif(title == "Welcome back!"):
     Hello old user
-#else
+#else:
     Unexpected page!
 #endif
 ```
@@ -241,7 +241,7 @@ The `#contains` tag accepts an array and a value as its two parameters, and retu
 ```leaf
 #if(contains(planets, "Earth")):
     Earth is here!
-#elseif
+#else:
     Earth is not in this array.
 #endif
 ```


### PR DESCRIPTION
Fix template errors when using the examples from the docs. Needed a colon after `else:` in order for things to work.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
