### PR TITLE
Update official MongoDB client reference to mention Vapor integration

### DIFF
--- a/4.0/docs/fluent/overview.md
+++ b/4.0/docs/fluent/overview.md
@@ -158,7 +158,7 @@ app.databases.use(.mysql(
 MongoDB is a popular schemaless NoSQL database designed for programmers. The driver supports all cloud hosting providers and self-hosted installations from version 3.4 and up.
 
 !!! note
-    This driver is powered by a community created and maintained MongoDB client called [MongoKitten](https://github.com/OpenKitten/MongoKitten). For the official MongoDB client, see [mongo-swift-driver](https://github.com/mongodb/mongo-swift-driver).
+    This driver is powered by a community created and maintained MongoDB client called [MongoKitten](https://github.com/OpenKitten/MongoKitten). MongoDB maintains an official client, [mongo-swift-driver](https://github.com/mongodb/mongo-swift-driver), along with a Vapor integration, [mongodb-vapor](https://github.com/mongodb/mongodb-vapor).
 
 To use MongoDB, add the following dependencies to your package.
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
Now that mongodb-vapor exists, it would be nice to include a mention of that here too since it will provide a better experience than using the driver directly.