### PR TITLE
Fixed typo in Google JWT code comment

### DIFF
--- a/4.0/docs/jwt.md
+++ b/4.0/docs/jwt.md
@@ -390,7 +390,7 @@ app.jwt.google.gSuiteDomainName = "..."
 Then, use the `req.jwt.google` helper to fetch and verify a Google JWT. 
 
 ```swift
-// Fetch and verify Microsoft JWT from Authorization header.
+// Fetch and verify Google JWT from Authorization header.
 app.get("google") { req -> EventLoopFuture<HTTPStatus> in
     req.jwt.google.verify().map { token in
         print(token) // GoogleIdentityToken


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->

The comment in the Google JWT snippet said 'Microsoft' instead of 'Google'.