### PR TITLE
Unique email for CreateUser in authentication.md

### DIFF
--- a/4.0/docs/authentication.md
+++ b/4.0/docs/authentication.md
@@ -258,7 +258,7 @@ final class User: Model, Content {
 }
 ```
 
-The model must be able to store a username, in this case an email, and a password hash. The corresponding migration for this example model is here:
+The model must be able to store a username, in this case an email, and a password hash. We also set `email` to be a unique field, to avoid duplicate users. The corresponding migration for this example model is here:
 
 ```swift
 import Fluent
@@ -274,6 +274,7 @@ extension User {
                 .field("name", .string, .required)
                 .field("email", .string, .required)
                 .field("password_hash", .string, .required)
+                .unique(on: "email", name: "no_duplicate_emails")
                 .create()
         }
 

--- a/4.0/docs/authentication.md
+++ b/4.0/docs/authentication.md
@@ -274,7 +274,7 @@ extension User {
                 .field("name", .string, .required)
                 .field("email", .string, .required)
                 .field("password_hash", .string, .required)
-                .unique(on: "email", name: "no_duplicate_emails")
+                .unique(on: "email")
                 .create()
         }
 


### PR DESCRIPTION
Tiny change to a already great documentation! For an example/tutorial that mimics a real world setup pretty well, it makes sense to have a unique check for the Users table.
