### PR TITLE
Add warning about property observer crashes

### DIFF
--- a/4.0/docs/fluent/model.md
+++ b/4.0/docs/fluent/model.md
@@ -160,7 +160,7 @@ var tag: String?
 ```
 
 !!! warning
-    A field that has a `willSet` property observer that references its current value or a `didSet` property observer that references its `oldValue` will result in a fatal error.
+    A non-optional field that has a `willSet` property observer that references its current value or a `didSet` property observer that references its `oldValue` will result in a fatal error.
 
 ## Relations
 

--- a/4.0/docs/fluent/model.md
+++ b/4.0/docs/fluent/model.md
@@ -159,6 +159,9 @@ For fields that contain an optional value, use `@OptionalField`.
 var tag: String?
 ```
 
+!!! warning
+    A field that has a `willSet` property observer that references its current value or a `didSet` property observer that references its `oldValue` will result in a fatal error.
+
 ## Relations
 
 Models can have zero or more relation properties referencing other models like `@Parent`, `@Children`, and `@Siblings`. Learn more about relations in the [relations](relations.md) section.


### PR DESCRIPTION
Use Swift's property observers as described in this PR's proposed change to the docs...

```
final class WillSetSample: Model {
    @ID(key: .id)
    var id: UUID?
    
    @Field(key: "name")
    var name: String {
        willSet {
            print(name)
        }
        didSet {
            print(oldValue)
        }
    }
    
    init() {}
    
    init(name: String) {
        self.name = name
    }
    
    static var schema: String = ""
}

final class DidSetSample: Model {
    @ID(key: .id)
    var id: UUID?
    
    @Field(key: "name")
    var name: String {
        didSet {
            print(oldValue)
        }
    }
    
    init() {}
    
    init(name: String) {
        self.name = name
    }
    
    static var schema: String = ""
}
```

...then simply running their initializers leads to a fatal error.

```
_ = WillSetSample(name: "")
_ = DidSetSample(name: "")
```

This is not obvious so I think it's worth adding the warning.