### PR TITLE
Note about updating the Dockerfile for async/await

### DIFF
--- a/4.0/docs/async.md
+++ b/4.0/docs/async.md
@@ -35,10 +35,14 @@ Finally update the `Run` target to mark it as an executable target:
 .executableTarget(name: "Run", dependencies: [.target(name: "App")]),
 ```
 
-Note: if you are running on Linux via Docker, then you'll also need to update all occurrences of the Swift version in your Dockerfile...
+Note: if you are deploying on Linux make sure you update the version of Swift there as well, e.g. on Heroku or in your Dockerfile. For example your Dockerfile would change to:
 
-```-FROM swift:5.2-focal as build
+```diff
+-FROM swift:5.2-focal as build
 +FROM swift:5.5-focal as build
+...
+-FROM swift:5.2-focal-slim
++FROM swift:5.5-focal-slim
 ```
 
 Now you can migrate existing code. Generally functions that return `EventLoopFuture`s are now `async`. For example:

--- a/4.0/docs/async.md
+++ b/4.0/docs/async.md
@@ -35,6 +35,12 @@ Finally update the `Run` target to mark it as an executable target:
 .executableTarget(name: "Run", dependencies: [.target(name: "App")]),
 ```
 
+Note: if you are running on Linux via Docker, then you'll also need to update all occurrences of the Swift version in your Dockerfile...
+
+```-FROM swift:5.2-focal as build
++FROM swift:5.5-focal as build
+```
+
 Now you can migrate existing code. Generally functions that return `EventLoopFuture`s are now `async`. For example:
 
 ```swift


### PR DESCRIPTION
Adds a note in the migrating-to-asyncawait doc to remind people to update the Swift version in their Dockerfile.