### PR TITLE
Changed withTaskGroup to withThrowingTaskGroup

### DIFF
--- a/4.0/docs/fluent/model.md
+++ b/4.0/docs/fluent/model.md
@@ -481,7 +481,7 @@ To create an array of models separately, use `map` + `flatten`.
 If using `async`/`await` you can use:
 
 ```swift
-await withTaskGroup(of: Void.self) { taskGroup in
+await withThrowingTaskGroup(of: Void.self) { taskGroup in
     [earth, mars].forEach { model in
         taskGroup.addTask { try await model.create(on: database) }
     }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

The model.md was incorrectly using `withTaskGroup` in the example.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
