### PR TITLE
Fix note and warning admonitions rendering

### DIFF
--- a/4.0/docs/deploy/heroku.md
+++ b/4.0/docs/deploy/heroku.md
@@ -68,7 +68,8 @@ The asterisk indicates current branch.
   other-branches
 ```
 
-> **Note**: If you don’t see any output and you’ve just performed `git init`. You’ll need to commit your code first then you’ll see output from the `git branch` command.
+!!! note 
+    If you don’t see any output and you’ve just performed `git init`. You’ll need to commit your code first then you’ll see output from the `git branch` command.
 
 
 If you’re _not_ currently on **master**, switch there by entering:

--- a/4.0/docs/leaf/getting-started.md
+++ b/4.0/docs/leaf/getting-started.md
@@ -41,9 +41,11 @@ app.views.use(.leaf)
 
 This tells Vapor to use the `LeafRenderer` when you call `req.view` in your code.
 
-> **Note:** Leaf has an internal cache for rendering pages. When the `Application`'s environment is set to `.development`, this cache is disabled, so that changes to templates take effect immediately. In `.production` and all other environments, the cache is enabled by default; any changes made to templates will not take effect until the application is restarted.
+!!! note 
+    Leaf has an internal cache for rendering pages. When the `Application`'s environment is set to `.development`, this cache is disabled, so that changes to templates take effect immediately. In `.production` and all other environments, the cache is enabled by default; any changes made to templates will not take effect until the application is restarted.
 
-!!!warning For Leaf to be able to find the templates when running from Xcode, you must set the [custom working directory](https://docs.vapor.codes/4.0/xcode/#custom-working-directory) for you Xcode workspace.
+!!! warning 
+    For Leaf to be able to find the templates when running from Xcode, you must set the [custom working directory](https://docs.vapor.codes/4.0/xcode/#custom-working-directory) for you Xcode workspace.
 
 ## Folder Structure
 

--- a/4.0/docs/leaf/overview.md
+++ b/4.0/docs/leaf/overview.md
@@ -272,4 +272,5 @@ The `#unsafeHTML` tag acts like a variable tag - e.g. `#(variable)`. However it 
 The time is #unsafeHTML(styledTitle)
 ```
 
-**Note:** you should be careful when using this tag to ensure that the variable you provide it does not expose your users to an XSS attack.
+!!! note 
+    You should be careful when using this tag to ensure that the variable you provide it does not expose your users to an XSS attack.


### PR DESCRIPTION
- A minor fix for the [admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/) used for the leaf docs
- Replaced inline **notes** with equivalent admonitions

Test Plan:

- Browse the rendered leaf docs

```sh
pip3 install -r requirements.txt
cd 4.0
mkdocs serve
```

Before:

<img width="713" alt="before" src="https://user-images.githubusercontent.com/11914919/144913324-884fbc77-0aeb-424a-b8b1-92a5920e43b1.png">

After:

<img width="724" alt="after" src="https://user-images.githubusercontent.com/11914919/144913356-ee01431c-238e-4840-8dca-f454151ae6f8.png">

