### PR TITLE
Fix function signature from beforeDecode to beforeEncode

### DIFF
--- a/4.0/docs/content.md
+++ b/4.0/docs/content.md
@@ -132,7 +132,7 @@ let name: String? = req.query["name"]
 
 ## Hooks
 
-Vapor will automatically call `beforeDecode` and `afterDecode` on a `Content` type. Default implementations are provided which do nothing, but you can use these methods to run custom logic.
+Vapor will automatically call `beforeEncode` and `afterDecode` on a `Content` type. Default implementations are provided which do nothing, but you can use these methods to run custom logic.
 
 ```swift
 // Runs after this Content is decoded. `mutating` is only required for structs, not classes.


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Found and fixed a typo in function name.

<!-- When this PR is merged, the title and body will be -->
Fix function signature from beforeDecode to beforeEncode

<!-- used to generate a release automatically. -->
