### PR TITLE
refactor: remove using deprecated method in Heroku deploy

### DIFF
--- a/4.0/docs/deploy/heroku.md
+++ b/4.0/docs/deploy/heroku.md
@@ -211,7 +211,8 @@ Unverified TLS is required if you are using Heroku Postgres's standard plan:
 
 ```swift
 if let databaseURL = Environment.get("DATABASE_URL"), var postgresConfig = PostgresConfiguration(url: databaseURL) {
-    postgresConfig.tlsConfiguration = .forClient(certificateVerification: .none)
+    postgresConfig.tlsConfiguration = .makeClientConfiguration()
+    postgresConfig.tlsConfiguration?.certificateVerification = .none
     app.databases.use(.postgres(
         configuration: postgresConfig
     ), as: .psql)


### PR DESCRIPTION


<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

`.forClient()` has been deprecated.

This change uses the recommended renamed method in the deprecated message  -> `Use 'makeClientConfiguration()' instead`

<!-- When this PR is merged, the title and body will be -->

<!-- used to generate a release automatically. -->
