### PR TITLE
Wrong reference to `AsyncBasicAuthenticator`

### DIFF
--- a/4.0/docs/authentication.md
+++ b/4.0/docs/authentication.md
@@ -150,7 +150,7 @@ struct UserAuthenticator: BearerAuthenticator {
 }
 ```
 
-If you're using `async`/`await` you can use `AsyncBasicAuthenticator` instead:
+If you're using `async`/`await` you can use `AsyncBearerAuthenticator` instead:
 
 ```swift
 import Vapor


### PR DESCRIPTION
`AsyncBasicAuthenticator` was referenced where it should've been `AsyncBearerAuthenticator`
