### PR TITLE
Add information about creating tables with parent-children relations

### DIFF
--- a/4.0/docs/fluent/relations.md
+++ b/4.0/docs/fluent/relations.md
@@ -126,7 +126,21 @@ try await sun.$planets.create(earth, on: database)
 
 This will set the parent id on the child model automatically.
 
-Since this relation does not store any values, no database schema entry is required. 
+!!! warning Since this relation does not store any values, no database schema entry is required for the parent table.  Creating one will likely lead to errors like `server: null value in column "planet_ids" of relation "star" violates not-null constraint`.
+
+
+If a table or collection does not yet exist, and you attempt to reference it, an error will be thrown.  You must create the parent table first, then the children table.
+
+```swift
+// Create the tables
+try await db.schema("stars")
+    .id()
+    .create()
+try await db.schema("planets")
+    .id()
+    .field("star_id", .uuid, .required, .references("stars", "id"))
+    .create()
+```
 
 ## Siblings
 
@@ -342,7 +356,3 @@ planet.$star.value = star
 ```
 
 This will attach the related model to the parent as if it was eager loaded or lazy loaded without an extra database query.
-
-## Migrations
-
-Sometimes setting up relations may require extra work during a migration.  See [schema builder](schema.md) for more info.

--- a/4.0/docs/fluent/relations.md
+++ b/4.0/docs/fluent/relations.md
@@ -342,3 +342,7 @@ planet.$star.value = star
 ```
 
 This will attach the related model to the parent as if it was eager loaded or lazy loaded without an extra database query.
+
+## Migrations
+
+Sometimes setting up relations may require extra work during a migration.  See [schema builder](schema.md) for more info.

--- a/4.0/docs/fluent/relations.md
+++ b/4.0/docs/fluent/relations.md
@@ -128,7 +128,6 @@ This will set the parent id on the child model automatically.
 
 !!! warning Since this relation does not store any values, no database schema entry is required for the parent table.  Creating one will likely lead to errors like `server: null value in column "planet_ids" of relation "star" violates not-null constraint`.
 
-
 If a table or collection does not yet exist, and you attempt to reference it, an error will be thrown.  You must create the parent table first, then the children table.
 
 ```swift

--- a/4.0/docs/fluent/schema.md
+++ b/4.0/docs/fluent/schema.md
@@ -186,7 +186,7 @@ To add a foreign key constraint to a field, use `.references`.
 .field("star_id", .uuid, .required, .references("stars", "id"))
 ```
 
-The above constraint requires that all values in the "star_id" field must match one of the values in Star's "id" field.
+The above constraint requires that all values in the "star_id" field must match one of the values in Star's "id" field, and that the "stars" table already exist.
 
 This same constraint could be added as a top-level constraint using `foreignKey`.
 
@@ -379,41 +379,3 @@ struct UserNameMigration: AsyncMigration {
 ```
 
 Note that for this migration to work, we need to be able to reference both the removed `name` field and the new `firstName` and `lastName` fields at the same time. Furthermore, the original `UserMigration` should continue to be valid. This would not be possible to do with key paths.
-
-## Creating Tables with Circular Relations
-
-If a table or collection does not yet exist, and you attempt to reference it, an error will be thrown.
-
-```swift
-// Parent
-try await db.schema("stars")
-    .id()
-    .field("planet_ids", .uuid, .required, .references("stars", "id")) // will fail
-    .create()
-
-// Children
-try await db.schema("planets")
-    .id()
-    .field("star_id", .uuid, .required, .references("planets", "id")) // will fail
-    .create()
-```
-
-To overcome this, restructure your migration to create the required table(s) first and then reference them.
-
-```swift
-// Create the tables
-try await db.schema("planets")
-    .id()
-    .create()
-try await db.schema("stars")
-    .id()
-    .create()
-
-// Update the tables with relations    
-try await db.schema("stars")
-    .field("planet_ids", .uuid, .required, .references("stars", "id"))
-    .update()
-try await db.schema("planets")
-    .field("star_id", .uuid, .required, .references("planets", "id"))
-    .update()
-```

--- a/4.0/docs/fluent/schema.md
+++ b/4.0/docs/fluent/schema.md
@@ -29,7 +29,7 @@ try await database.schema("planets")
     .create()
 ```
 
-If a table or collection with the chosen name already exists, an error will be thrown. To ignore this, use `.ignoreExisting()`.
+If a table or collection with the chosen name already exists, an error will be thrown. To ignore this, use `.ignoreExisting()`. 
 
 ### Update
 
@@ -410,10 +410,10 @@ try await db.schema("stars")
     .create()
 
 // Update the tables with relations    
-try await db.schema("planets")
-    .field("star_ids", .uuid, .required, .references("stars", "id"))
-    .update()
 try await db.schema("stars")
-    .field("planet_id", .uuid, .required, .references("planets", "id"))
+    .field("planet_ids", .uuid, .required, .references("stars", "id"))
+    .update()
+try await db.schema("planets")
+    .field("star_id", .uuid, .required, .references("planets", "id"))
     .update()
 ```


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
I've added some information about creating tables with parent-children relationships.  Specifically pointing out a common mistake about creating tables at the same time which contain a reference, and emphasizing that parents don't have a column for their children.

When I was creating my first tables, I ran into this error, which, after I resolved it, prompted this PR:
```
[ WARNING ] server: relation "table_name" does not exist (RangeVarGetRelidExtended)
Swift/ErrorType.swift:200: Fatal error: Error raised at top level: server: relation "table_name" does not exist (RangeVarGetRelidExtended)
```

and then later this:
```
server: null value in column "child_ids" of relation "parent" violates not-null constraint
```

I'm new to Vapor/Fluent so let me know if this info is not good guidance/not correct.  Let me know what you'd like changed.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
