### PR TITLE
Add i18n Support

### DIFF
--- a/4.0/docs/index.nl.md
+++ b/4.0/docs/index.nl.md
@@ -1,0 +1,32 @@
+Dit is de documentatie voor Vapor, een web framework voor Swift.
+
+Vapor is het meest gebruikte web framework  voor Swift. Het biedt een prachtig expressieve en gebruiksvriendelijke basis voor uw volgende website of API.
+
+## Talen
+
+- English [(docs.vapor.codes)](https://docs.vapor.codes)
+- 简体中文 [(cn.docs.vapor.codes)](https://cn.docs.vapor.codes)
+
+## Eerste stappen
+
+Als dit je eerste keer is dat je Vapor gebruikt, ga naar [Install → macOS](install/macos.md) om Swift en Vapor te installeren.
+
+Wanneer dat je Vapor hebt geinstalleerd, bekijk dan [Getting Started → Hello, world](hello-world.md) om je eerste Vapor app te maken.
+
+## Andere bronnen
+
+Hier zijn een paar andere geweldige plaatsen om meer informatie te vinden over Vapor
+
+| naam           | beschrijving                                      | link                                                            |
+|----------------|--------------------------------------------------|-----------------------------------------------------------------|
+| Vapor Discord  | Praat met duizenden Vapor developers.         | [visit &rarr;](https://vapor.team)                               |
+| API docs       | Auto-generated documentation from code comments. | [visit &rarr;](https://api.vapor.codes)                          |
+| Stack Overflow | Vraag en beantwoord vragen met de `vapor` tag.   | [visit &rarr;](https://stackoverflow.com/questions/tagged/vapor) |
+| Swift Forums  | Post in de Vapor sectie van de Swift.org forums.  | [visit &rarr;](https://forums.swift.org/c/related-projects/vapor)           |
+| Source Code    | Leer hoe Vapor werkt onder de motorkap.            | [visit &rarr;](https://github.com/vapor/vapor)                  |
+| GitHub Issues  | Meld fouten of verzoek functies aan op GitHub.       | [visit &rarr;](https://github.com/vapor/vapor/issues)           |
+
+
+## Auteurs
+
+[Tanner Nelson](mailto:tanner@vapor.codes), [Logan Wright](mailto:logan@vapor.codes), en de honderden leden van de Vapor gemeenschap.

--- a/4.0/mkdocs.yml
+++ b/4.0/mkdocs.yml
@@ -58,6 +58,33 @@ markdown_extensions:
   - toc:
       permalink: true
 
+# Plugins
+plugins:
+  # i18n plugin documentation
+  # https://github.com/ultrabug/mkdocs-static-i18n
+  - i18n:
+      default_language: 'en'
+      # Add the new languages here. DON'T CHANGE THE DEFAULT LANGUAGE
+      languages:
+        en: 
+          name: English
+          build: true
+        nl: 
+          name: Nederlands
+          site_name: Vapor Documentatie
+          build: true
+        fr:
+          name: Français
+          site_name: Documentation Vapor
+          build: true
+      # Add navigation translations here
+      nav_translations:
+        nl:
+          Welcome: Welkom
+        fr: 
+          Welcome: Bienvenue
+
+
 nav:
 - Welcome: "index.md"
 - Install:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,54 @@
 # Documentation
 
 Read the docs at [docs.vapor.codes](https://docs.vapor.codes)
+
+## Contributing
+
+If you wish to contribute to the Vapor documentation by translating, follow these steps below.
+> For now this only applies to the Vapor 4 Documentation.
+
+To start of, install [Python3](https://www.python.org/download/releases/3.0/). Once you have done that, run `pip install -r requirements.txt` in the root directory of this repository. This will install all the needed dependencies in order to be able to build the documentation.  
+
+Following the installation of the dependencies, check if your language you want to translate to is already included in the `mkdocs.yml` file. If it is not, then you can add it like this:
+```yaml
+languages:
+  # Structure
+  <language iso code>:
+    name: <The name of the language>
+    site_name: <The translated site name>
+    build: true # Whether the documentation gets build or not. Turn this to false for all languages you're not translating if building takes too long
+
+  # Example
+  nl:
+    name: Nederlands
+    site_name: Vapor Documentatie
+    build: false
+```
+> NOTE: The language iso code you have to insert has to conform to the ISO 639-1 Standard. More information can be found [here](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+
+If there are navigation components that have to be translated, then you can add them under `nav_translations` in the mkdocs file. This is done by specifying a keyword defined in the `nav:` section of the `mkdocs.yml` file and then adding the translation. An example can be found below of how to add those:
+```yaml
+nav_translations:
+  # Structure
+  <language code>:
+    <keyword>: <translation>
+
+  # Example
+  nl:
+    Welcome: Welkom
+    Install: Installeren
+```
+
+Copy the markdown file you would like to translate and name it `<original name file>.<language code>.md`. 
+For example:
+```
+- index.md <- the original english documentation
+- index.nl.md <- the dutch translation of the english documentation file
+```
+
+You can check it out by running `mkdocs serve` in the terminal. Once you are satisfied with your translations, feel free to create a PR. Don't forget to turn the `build` flag to true for all languages!
+
+> NOTE: If a file isn't translated, it will just default to the default language file. So you don't have to translate everything all at once.
+
+
+  

--- a/README.md
+++ b/README.md
@@ -3,9 +3,15 @@
 Read the docs at [docs.vapor.codes](https://docs.vapor.codes)
 
 ## Contributing
+### *Mistakes*
+---
+If you have found any mistakes in the documentation, feel free to create a PR to fix it.
+
+### *Translating*
+---
+> For now this only applies to the Vapor 4 Documentation.
 
 If you wish to contribute to the Vapor documentation by translating, follow these steps below.
-> For now this only applies to the Vapor 4 Documentation.
 
 To start of, install [Python3](https://www.python.org/download/releases/3.0/). Once you have done that, run `pip install -r requirements.txt` in the root directory of this repository. This will install all the needed dependencies in order to be able to build the documentation.  
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,11 @@
 Read the docs at [docs.vapor.codes](https://docs.vapor.codes)
 
 ## Contributing
-### *Mistakes*
----
+
 If you want to add information to the docs or have found any mistakes you wish to fix, feel free to create a PR  for the change.
 
 ### *Translating*
 ---
-> For now this only applies to the Vapor 4 Documentation.
 
 Localised docs are incredibly useful for allowing people to learn Vapor in their native language. If you wish to contribute to the Vapor documentation by translating, follow the steps below.
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ Read the docs at [docs.vapor.codes](https://docs.vapor.codes)
 ## Contributing
 ### *Mistakes*
 ---
-If you have found any mistakes in the documentation, feel free to create a PR to fix it.
+If you want to add information to the docs or have found any mistakes you wish to fix, feel free to create a PR  for the change.
 
 ### *Translating*
 ---
 > For now this only applies to the Vapor 4 Documentation.
 
-If you wish to contribute to the Vapor documentation by translating, follow these steps below.
+Localised docs are incredibly useful for allowing people to learn Vapor in their native language. If you wish to contribute to the Vapor documentation by translating, follow the steps below.
 
-To start of, install [Python3](https://www.python.org/download/releases/3.0/). Once you have done that, run `pip install -r requirements.txt` in the root directory of this repository. This will install all the needed dependencies in order to be able to build the documentation.  
+You'll need Python3 to build the docs. You can download this from the [Python Website](https://www.python.org/download/releases/3.0/) or install via Homebrew. Once installed, run `pip install -r requirements.txt` in the root directory of this repository. This will install all the needed dependencies in order to be able to build the documentation.  
 
 Following the installation of the dependencies, check if your language you want to translate to is already included in the `mkdocs.yml` file. If it is not, then you can add it like this:
 ```yaml
@@ -22,15 +22,15 @@ languages:
   <language iso code>:
     name: <The name of the language>
     site_name: <The translated site name>
-    build: true # Whether the documentation gets build or not. Turn this to false for all languages you're not translating if building takes too long
+    build: true # Whether the documentation gets build or not. You can disable this if you don't want to build your language or want to temporarily disable other languages
 
   # Example
   nl:
     name: Nederlands
     site_name: Vapor Documentatie
-    build: false
+    build: true
 ```
-> NOTE: The language iso code you have to insert has to conform to the ISO 639-1 Standard. More information can be found [here](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+> NOTE: The language code you have to add must conform to the ISO 639-1 Standard. More information can be found [here](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
 
 If there are navigation components that have to be translated, then you can add them under `nav_translations` in the mkdocs file. This is done by specifying a keyword defined in the `nav:` section of the `mkdocs.yml` file and then adding the translation. An example can be found below of how to add those:
 ```yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ mkdocs>=1
 mkdocs-material>=3
 Pygments>=2.2
 pymdown-extensions>=4.11
+mkdocs-static-i18n>=0.45


### PR DESCRIPTION
In this PR there is added I18N support to the documentation site. This way we don't have to create a seperate website/repo for the documentation. 

The `requirements.txt` file is updated to include the i18n package.
The README is updated to include an explanation on how people can contribute to the documentation

closes #647 