### PR TITLE
Fix custom-tags to make it clear where the implementation is

### DIFF
--- a/docs/leaf/custom-tags.md
+++ b/docs/leaf/custom-tags.md
@@ -22,20 +22,22 @@ Now let's implement the `render(_:)` method. The `LeafContext` context passed to
 ```swift
 struct NowTagError: Error {}
 
-let formatter = DateFormatter()
-switch ctx.parameters.count {
-case 0: formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-case 1:
-    guard let string = ctx.parameters[0].string else {
-        throw NowTagError()
-    }
-    formatter.dateFormat = string
-default:
-    throw NowTagError()
+func render(_ ctx: LeafContext) throws -> LeafData {
+	let formatter = DateFormatter()
+	switch ctx.parameters.count {
+	case 0: formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+	case 1:
+	    guard let string = ctx.parameters[0].string else {
+	        throw NowTagError()
+	    }
+	    formatter.dateFormat = string
+	default:
+	    throw NowTagError()
+	}
+	
+	let dateAsString = formatter.string(from: Date())
+	return LeafData.string(dateAsString)
 }
-
-let dateAsString = formatter.string(from: Date())
-return LeafData.string(dateAsString)
 ```
 
 !!! tip


### PR DESCRIPTION
The implementation to `render` is just hanging out there in the code block. Enclosed it as a function body.
