### PR TITLE
Create gh action for creating translation issues

### DIFF
--- a/.github/workflows/translation-issue-template.md
+++ b/.github/workflows/translation-issue-template.md
@@ -1,0 +1,13 @@
+---
+title: Translation needed for {{'#'}}{{env.PR_NUMBER}}
+---
+
+The docs have been updated in PR {{'#'}}{{env.PR_NUMBER}}. The translations should be updated if required.
+
+Languages:
+- [ ] English
+- [ ] Chinese
+- [ ] German
+- [ ] Dutch
+
+Assigned to @vapor/translations - please submit a PR with the relevant updates and check the box once merged. Please ensure you tag your PR with the `translation-update` so it doesn't create a new issue!

--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -11,13 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Find PR
-      uses: jwalton/gh-find-current-pr@v1
+      uses: 8BitJonny/gh-get-current-pr@2.1.0
       id: find-pr
       with:
         state: all
+    - uses: actions/checkout@v2
     - name: Create issue
-      if: steps.find-pr.outputs.number && !contains(steps.find-pr.outputs.body, 'no-doc-update')
-      uses: nashmaniac/create-issue-action@v1.1
+      if: steps.find-pr.outputs.number && !contains(steps.find-pr.outputs.pr_labels, 'translation-update') && !contains(steps.find-pr.outputs.pr_labels, 'no-translation-needed')
+      uses: JasonEtco/create-an-issue@v2
+      env:
+        PR_NUMBER: ${{ steps.find-pr.outputs.number }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        title: Need translation for ${{ '#' }}${{steps.find-pr.outputs.pr}}
-        body: Need translation for ${{ '#' }}${{steps.find-pr.outputs.pr}}
+        assignees: vapor/translations
+        filename: .github/workflows/translation-issue-template.md

--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -1,0 +1,23 @@
+name: Check PR and create issue for translation
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create:
+    name: Create issue
+    runs-on: ubuntu-latest
+    steps:
+    - name: Find PR
+      uses: jwalton/gh-find-current-pr@v1
+      id: find-pr
+      with:
+        state: all
+    - name: Create issue
+      if: steps.find-pr.outputs.number && !contains(steps.find-pr.outputs.body, 'no-doc-update')
+      uses: nashmaniac/create-issue-action@v1.1
+      with:
+        title: Need translation for ${{ '#' }}${{steps.find-pr.outputs.pr}}
+        body: Need translation for ${{ '#' }}${{steps.find-pr.outputs.pr}}

--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -23,5 +23,4 @@ jobs:
         PR_NUMBER: ${{ steps.find-pr.outputs.number }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        assignees: vapor/translations
         filename: .github/workflows/translation-issue-template.md


### PR DESCRIPTION
### Create a github action action as described in https://github.com/vapor/docs/issues/665 

The only issue with I'm having with it is that it builds a container for the issue creating action before we check if we want to create an issue. So essentially we are using 10-20s each run for a thing that may be not used.

 Please let me know what you want to see in the issue title and body. Right now it's "Need translation for *link to PR*"

And the `no-doc-update` where should we check for it? The current implementation looks for in the PR body

