### PR TITLE
Added closure documentation for redirect

### DIFF
--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -756,7 +756,21 @@ When protecting routes for an API, you traditionally return an HTTP response wit
 let protectedRoutes = app.grouped(User.redirectMiddleware(path: "/login?loginRequired=true"))
 ```
 
+The `RedirectMiddleware` object also supports passing a closure that returns a `String` during creation for advanced url handling. For instance, uncluding the path redirected from as query paramater to the redirect target for state management.
+
+```swift
+let redirectMiddleware = User.redirectMiddleware { req -> String in
+  return "/login?authRequired=true&next=\(req.url.path)"
+}
+```
+
 This works similar to the `GuardMiddleware`. Any requests to routes registered to `protectedRoutes` that aren't authenticated will be redirected to the path provided. This allows you to tell your users to log in, rather than just providing a **401 Unauthorized**.
+
+Be sure to include a Session Authenticator before the `RedirectMiddleware` to prevent subsequent requests to the protected routes from asking for a password.
+
+```swift
+let protectedRoutes = app.grouped([User.SessionAuthenticator(), redirecteMiddleware])
+```
 
 ### Form Log In
 

--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -756,7 +756,7 @@ When protecting routes for an API, you traditionally return an HTTP response wit
 let protectedRoutes = app.grouped(User.redirectMiddleware(path: "/login?loginRequired=true"))
 ```
 
-The `RedirectMiddleware` object also supports passing a closure that returns a `String` during creation for advanced url handling. For instance, uncluding the path redirected from as query paramater to the redirect target for state management.
+The `RedirectMiddleware` object also supports passing a closure that returns the redirect path as a `String` during creation for advanced url handling. For instance, including the path redirected from as query parameter to the redirect target for state management.
 
 ```swift
 let redirectMiddleware = User.redirectMiddleware { req -> String in

--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -766,7 +766,7 @@ let redirectMiddleware = User.redirectMiddleware { req -> String in
 
 This works similar to the `GuardMiddleware`. Any requests to routes registered to `protectedRoutes` that aren't authenticated will be redirected to the path provided. This allows you to tell your users to log in, rather than just providing a **401 Unauthorized**.
 
-Be sure to include a Session Authenticator before the `RedirectMiddleware` to prevent subsequent requests to the protected routes from asking for a password.
+Be sure to include a Session Authenticator before the `RedirectMiddleware` to ensure the authenticated user is loaded before running through the `RedirectMiddleware`.
 
 ```swift
 let protectedRoutes = app.grouped([User.SessionAuthenticator(), redirecteMiddleware])


### PR DESCRIPTION
This describes how to use the closure argument to the RedirectMiddleware to generate the string to redirect to instead of a static argument.
Also catches a pitfall for RedirectMiddleware by suggesting the use of User.SessionAutheticator() to manage logged in users.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
