### PR TITLE
Replace old RediStack API links

### DIFF
--- a/docs/redis/overview.md
+++ b/docs/redis/overview.md
@@ -32,7 +32,7 @@ targets: [
 
 ## Configure
 
-Vapor employs a pooling strategy for [`RedisConnection`](https://docs.redistack.info/Classes/RedisConnection.html) instances, and there are several options to configure individual connections as well as the pools themselves.
+Vapor employs a pooling strategy for [`RedisConnection`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redisconnection) instances, and there are several options to configure individual connections as well as the pools themselves.
 
 The bare minimum required for configuring Redis is to provide a URL to connect to:
 
@@ -98,11 +98,11 @@ This is known as a "cold start" connection, and does have some overhead over mai
 This option determines the behavior of how the maximum connection count is maintained.
 
 !!! seealso
-    Refer to the [`RedisConnectionPoolSize`](https://docs.redistack.info/Enums/RedisConnectionPoolSize.html) API to be familiar with what options are available.
+    Refer to the `RedisConnectionPoolSize` API to be familiar with what options are available.
 
 ## Sending a Command
 
-You can send commands using the `.redis` property on any [`Application`](https://api.vapor.codes/vapor/main/Vapor/Application/) or [`Request`](https://api.vapor.codes/vapor/main/Vapor/Request/) instance, which will give you access to a [`RedisClient`](https://docs.redistack.info/Protocols/RedisClient.html).
+You can send commands using the `.redis` property on any [`Application`](https://api.vapor.codes/vapor/main/Vapor/Application/) or [`Request`](https://api.vapor.codes/vapor/main/Vapor/Request/) instance, which will give you access to a [`RedisClient`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redisclient).
 
 Any `RedisClient` has several extensions for all of the various [Redis commands](https://redis.io/commands).
 
@@ -148,9 +148,9 @@ There is a defined lifecycle to a subscription:
 1. **message**: invoked 0+ times as messages are published to the subscribed channels
 1. **unsubscribe**: invoked once when the subscription ends, either by request or the connection being lost
 
-When you create a subscription, you must provide at least a [`messageReceiver`](https://docs.redistack.info/Typealiases.html#/s:9RediStack32RedisSubscriptionMessageReceiver) to handle all messages that are published by the subscribed channel.
+When you create a subscription, you must provide at least a [`messageReceiver`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redissubscriptionmessagereceiver) to handle all messages that are published by the subscribed channel.
 
-You can optionally provide a [`RedisSubscriptionChangeHandler`](https://docs.redistack.info/Typealiases.html#/s:9RediStack30RedisSubscriptionChangeHandlera) for `onSubscribe` and `onUnsubscribe` to handle their respective lifecycle events.
+You can optionally provide a `RedisSubscriptionChangeHandler` for `onSubscribe` and `onUnsubscribe` to handle their respective lifecycle events.
 
 ```swift
 // creates 2 subscriptions, one for each given channel

--- a/docs/redis/overview.nl.md
+++ b/docs/redis/overview.nl.md
@@ -32,7 +32,7 @@ targets: [
 
 ## Configuratie
 
-Vapor gebruikt een pooling strategie voor [`RedisConnection`](https://docs.redistack.info/Classes/RedisConnection.html) instanties, en er zijn verschillende opties om zowel individuele verbindingen als de pools zelf te configureren.
+Vapor gebruikt een pooling strategie voor [`RedisConnection`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redisconnection) instanties, en er zijn verschillende opties om zowel individuele verbindingen als de pools zelf te configureren.
 
 Het absolute minimum dat nodig is voor het configureren van Redis is het opgeven van een URL om verbinding mee te maken:
 
@@ -98,11 +98,11 @@ Dit staat bekend als een "koude start" verbinding, en heeft wel enige overhead t
 Deze optie bepaalt het gedrag van hoe het maximum aantal verbindingen wordt bijgehouden.
 
 !!! seealso "Zie ook"
-    Raadpleeg de [`RedisConnectionPoolSize`](https://docs.redistack.info/Enums/RedisConnectionPoolSize.html) API om te weten welke mogelijkheden beschikbaar zijn.
+    Raadpleeg de `RedisConnectionPoolSize` API om te weten welke mogelijkheden beschikbaar zijn.
 
 ## Een commando versturen
 
-Je kunt commando's sturen met de `.redis` eigenschap op elke [`Application`](https://api.vapor.codes/vapor/main/Vapor/Application/) of [`Request`](https://api.vapor.codes/vapor/main/Vapor/Request/) instantie, die je toegang geeft tot een [`RedisClient`](https://docs.redistack.info/Protocols/RedisClient.html).
+Je kunt commando's sturen met de `.redis` eigenschap op elke [`Application`](https://api.vapor.codes/vapor/main/Vapor/Application/) of [`Request`](https://api.vapor.codes/vapor/main/Vapor/Request/) instantie, die je toegang geeft tot een [`RedisClient`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redisclient).
 
 Elke `RedisClient` heeft verschillende extensies voor alle verschillende [Redis commando's](https://redis.io/commands).
 
@@ -148,9 +148,9 @@ Er is een bepaalde levenscyclus voor een abonnement:
 1. **message**: 0+ keer aangeroepen als berichten worden gepubliceerd in de geabonneerde kanalen
 1. **unsubscribe**: eenmaal aangeroepen wanneer het abonnement eindigt, hetzij door een verzoek, hetzij doordat de verbinding wordt verbroken
 
-Wanneer je een abonnement aanmaakt, moet je minstens een [`messageReceiver`](https://docs.redistack.info/Typealiases.html#/s:9RediStack32RedisSubscriptionMessageReceiver) voorzien om alle berichten te behandelen die gepubliceerd worden door het geabonneerde kanaal.
+Wanneer je een abonnement aanmaakt, moet je minstens een [`messageReceiver`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redissubscriptionmessagereceiver) voorzien om alle berichten te behandelen die gepubliceerd worden door het geabonneerde kanaal.
 
-U kunt optioneel een [`RedisSubscriptionChangeHandler`](https://docs.redistack.info/Typealiases.html#/s:9RediStack30RedisSubscriptionChangeHandlera) opgeven voor `onSubscribe` en `onUnsubscribe` om hun respectievelijke lifecycle events af te handelen.
+U kunt optioneel een `RedisSubscriptionChangeHandler` opgeven voor `onSubscribe` en `onUnsubscribe` om hun respectievelijke lifecycle events af te handelen.
 
 ```swift
 // creëert 2 abonnementen, een voor elk gegeven kanaal

--- a/docs/redis/overview.zh.md
+++ b/docs/redis/overview.zh.md
@@ -32,7 +32,7 @@ targets: [
 
 ## 配置
 
-Vapor 对 [`RedisConnection`](https://docs.redistack.info/Classes/RedisConnection.html) 实例采用池化策略，并且有几个选项可以配置单个连接以及池本身。
+Vapor 对 [`RedisConnection`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redisconnection) 实例采用池化策略，并且有几个选项可以配置单个连接以及池本身。
 
 配置 Redis 的最低要求是提供一个 URL 来连接：
 
@@ -98,11 +98,11 @@ let serverAddresses: [SocketAddress] = [
 此选项确定如何维护最大连接数的行为。
 
 !!! 也可以看看
-    请参阅 [`RedisConnectionPoolSize`](https://docs.redistack.info/Enums/RedisConnectionPoolSize.html) API 文档以熟悉更多可用选项。
+    请参阅 `RedisConnectionPoolSize` API 文档以熟悉更多可用选项。
 
 ## 发送命令
 
-你可以使用  [`Application`](https://api.vapor.codes/vapor/main/Vapor/Application/) 或 [`Request`](https://api.vapor.codes/vapor/main/Vapor/Request/) 实例上的 `.redis` 属性发送命令，这使得你可以访问 [`RedisClient`](https://docs.redistack.info/Protocols/RedisClient.html)。
+你可以使用  [`Application`](https://api.vapor.codes/vapor/main/Vapor/Application/) 或 [`Request`](https://api.vapor.codes/vapor/main/Vapor/Request/) 实例上的 `.redis` 属性发送命令，这使得你可以访问 [`RedisClient`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redisclient)。
 
 对于各别的 [Redis 命令](https://redis.io/commands)，`RedisClient` 都有其对应的扩展。
 
@@ -148,9 +148,9 @@ Redis 支持进入[发布/订阅模式](https://redis.io/topics/pubsub)，其中
 1. **message**：在消息发布到订阅频道时调用 0+ 次
 1. **unsubscribe**：订阅结束时调用一次，无论是通过请求还是连接丢失
 
-创建订阅时，你必须至少提供一个 [`messageReceiver`](https://docs.redistack.info/Typealiases.html#/s:9RediStack32RedisSubscriptionMessageReceiver) 来处理订阅频道发布的所有消息。
+创建订阅时，你必须至少提供一个 [`messageReceiver`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redissubscriptionmessagereceiver) 来处理订阅频道发布的所有消息。
 
-你可以选择为 `onSubscribe` 和 `onUnsubscribe`  提供一个 [`RedisSubscriptionChangeHandler`](https://docs.redistack.info/Typealiases.html#/s:9RediStack30RedisSubscriptionChangeHandlera) 来处理它们各自的生命周期事件。
+你可以选择为 `onSubscribe` 和 `onUnsubscribe`  提供一个 `RedisSubscriptionChangeHandler` 来处理它们各自的生命周期事件。
 
 ```swift
 // 创建2个订阅，每个给定频道一个订阅


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
RediStack documentation has moved from docs.redistack.info to swiftpackageindex. Hence the link referencing the first site were dead links. These have been replaced with the updated links