### PR TITLE
Add release notes page

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,9 +7,18 @@ Because it is hard, if not impossible to keep the documentation up-to-date const
 
 
 ## Routing Kit
+1.14.2 Extend routing-kit async options
 
 
 
 ## Console Kit
 
+<!--Store updated release-notes in temp file -->
+```bash
+awk '/<Title that the text should be under>/ {print; print "1.14.2 Extend routing-kit async options"; next}1' release-notes.md > test.txt
+```
 
+<!--Replace release-notes with updated release notes -->
+```bash
+awk test.txt > release-notes.md
+```

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,15 @@
+# Vapor Release Notes
+
+Because it is hard, if not impossible to keep the documentation up-to-date constantly, here is where you will find release notes of various different packages linked to the Vapor ecosystem.
+
+## Vapor 
+
+
+
+## Routing Kit
+
+
+
+## Console Kit
+
+

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,24 +1,95 @@
 # Vapor Release Notes
 
-Because it is hard, if not impossible to keep the documentation up-to-date constantly, here is where you will find release notes of various different packages linked to the Vapor ecosystem.
+Because it is hard, if not impossible to keep the documentation up-to-date constantly, here you will find release notes of various different packages linked to the Vapor ecosystem.
 
 ## vapor 
 
 
-
-## Routing Kit
-1.14.2 Extend routing-kit async options
+## fluent
 
 
+## fluent-kit
 
-## Console Kit
 
-<!--Store updated release-notes in temp file -->
-```bash
-awk '/<Title that the text should be under>/ {print; print "1.14.2 Extend routing-kit async options"; next}1' release-notes.md > test.txt
-```
+## leaf
 
-<!--Replace release-notes with updated release notes -->
-```bash
-awk test.txt > release-notes.md
-```
+
+## leaf-kit
+
+
+## fluent-postgres-driver
+
+
+## fluent-mysql-driver
+
+
+## fluent-sqlite-driver
+
+
+## fluent-mongo-driver
+
+
+## postgres-nio
+
+
+## mysql-nio
+
+
+## sqlite-nio
+
+
+## postgres-kit
+
+
+## mysql-kit
+
+
+## sqlite-kit
+
+
+## sql-kit
+
+
+## apns
+
+
+## queues
+
+
+## queues-redis-driver
+
+
+## redis
+
+
+## jwt
+
+
+## jwt-kit
+
+
+## websocket-kit
+
+
+## routing-kit
+
+
+## console-kit
+
+
+## async-kit
+
+
+## multipart-kit
+
+
+## toolbox
+
+
+## core
+
+
+## swift-codecov-action
+
+
+## api-docs

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,7 +2,7 @@
 
 Because it is hard, if not impossible to keep the documentation up-to-date constantly, here is where you will find release notes of various different packages linked to the Vapor ecosystem.
 
-## Vapor 
+## vapor 
 
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -252,3 +252,4 @@ nav:
 - Version (4.0):
     - Legacy Docs: "version/legacy-docs.md"
     - Upgrading: "upgrading.md"
+- Release Notes: "release-notes.md"


### PR DESCRIPTION
This will add a new file called `release-notes.md`.

The workflow to add release notes will keep this file updated whenever there is a release on a package. 

The only mandatory thing to do (if new packages with releases will pop up) is to add them to the file. For now, this is already done for every package that has releases.

closes #696 