### PR TITLE
Fix type declaration in AsyncModelMiddleware example

### DIFF
--- a/docs/fluent/model.md
+++ b/docs/fluent/model.md
@@ -564,7 +564,7 @@ or if using `async`/`await`:
 
 ```swift
 struct PlanetMiddleware: AsyncModelMiddleware {
-    func create(model: Planet, on db: Database, next: AnyModelResponder) async throws {
+    func create(model: Planet, on db: Database, next: AnyAsyncModelResponder) async throws {
         // The model can be altered here before it is created.
         model.name = model.name.capitalized()
         try await next.create(model, on: db)


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
The example for defining a model middleware has an incorrect type declaration for the `next` value in the middleware method `create` when using async/await.

Copying and pasting this will cause errors and may take a user some time to figure out what's wrong.

The type for `next` in the async/await middleware method `create` has been updated to `AnyAsyncModelResponder` so it conforms to `AsyncModelMiddleware` protocol.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
