### PR TITLE
Update nginx.md to remove duplicate

### DIFF
--- a/docs/deploy/nginx.md
+++ b/docs/deploy/nginx.md
@@ -104,7 +104,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass_header Server;
         proxy_connect_timeout 3s;
         proxy_read_timeout 10s;
     }

--- a/docs/deploy/nginx.nl.md
+++ b/docs/deploy/nginx.nl.md
@@ -104,7 +104,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass_header Server;
         proxy_connect_timeout 3s;
         proxy_read_timeout 10s;
     }

--- a/docs/deploy/nginx.zh.md
+++ b/docs/deploy/nginx.zh.md
@@ -90,7 +90,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass_header Server;
         proxy_connect_timeout 3s;
         proxy_read_timeout 10s;
     }


### PR DESCRIPTION
Fixed where there's a duplicate  proxy_pass_header Server

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Remove a duplicate header entry in the nginx page of the docs
<!-- When this PR is merged, the title and body will be --> Remove duplicate header in nginx docs
<!-- used to generate a release automatically. -->
