### PR TITLE
Fix typo in Fluent -> Advanced

### DIFF
--- a/docs/fluent/advanced.md
+++ b/docs/fluent/advanced.md
@@ -174,7 +174,7 @@ var queryDocument = Document()
 queryDocument["name"]["$regex"] = "e"
 queryDocument["name"]["$options"] = "i"
 
-let planets = try Planet.query(on: req.db).filter(.custom(nameDocument)).all()
+let planets = try Planet.query(on: req.db).filter(.custom(queryDocument)).all()
 ```
 
 This will return planets containing 'e' and 'E'. You can also create any other complex RegEx accepted by MongoDB.

--- a/docs/fluent/advanced.nl.md
+++ b/docs/fluent/advanced.nl.md
@@ -174,7 +174,7 @@ import FluentMongoDriver
 var queryDocument = Document()
 queryDocument["name"]["$regex"] = "e"
 queryDocument["name"]["$options"] = "i"
-let planets = try Planet.query(on: req.db).filter(.custom(nameDocument)).all()
+let planets = try Planet.query(on: req.db).filter(.custom(queryDocument)).all()
 ```
 
 Dit geeft planeten terug die 'e' en 'E' bevatten. U kunt ook elke andere complexe RegEx maken die door MongoDB wordt geaccepteerd.

--- a/docs/fluent/advanced.zh.md
+++ b/docs/fluent/advanced.zh.md
@@ -173,7 +173,7 @@ var queryDocument = Document()
 queryDocument["name"]["$regex"] = "e"
 queryDocument["name"]["$options"] = "i"
 
-let planets = try Planet.query(on: req.db).filter(.custom(nameDocument)).all()
+let planets = try Planet.query(on: req.db).filter(.custom(queryDocument)).all()
 ```
 
 这将返回包含 'e' 和 'E' 的行星。你还可以创建 MongoDB 接受的任何其他复杂的 RegEx。


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Fixes a typo in the Fluent docs under advanced where the variable was defined as `queryDocument` but then used as `nameDocument`.

e.g:

> import FluentMongoDriver
> 
> var **queryDocument** = Document()
> queryDocument["name"]["$regex"] = "e"
> queryDocument["name"]["$options"] = "i"
> 
> let planets = try Planet.query(on: req.db).filter(.custom(**nameDocument**)).all()


<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
