### PR TITLE
add note about session cookie

### DIFF
--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -748,6 +748,9 @@ These middlewares do the following:
 * the sessions middleware takes the session cookie provided in the request and converts it into a session
 * the session authenticator takes the session and see if there is an authenticated user for that session. If so, the middleware authenticates the request. In the response, the session authenticator sees if the request has an authenticated user and saves them in the session so they're authenticated in the next request.
 
+!!! tip
+    The session cookie is not set to `secure` and `httpOnly` by default. Check Vapor's [Session API](../advanced/sessions.md#configuration) how to configure cookies.
+
 ### Protecting Routes
 
 When protecting routes for an API, you traditionally return an HTTP response with a status code such as **401 Unauthorized** if the request is not authenticated. However, this isn't a very good user experience for someone using a browser. Vapor provides a `RedirectMiddleware` for any `Authenticatable` type to use in this scenario:

--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -748,7 +748,7 @@ These middlewares do the following:
 * the sessions middleware takes the session cookie provided in the request and converts it into a session
 * the session authenticator takes the session and see if there is an authenticated user for that session. If so, the middleware authenticates the request. In the response, the session authenticator sees if the request has an authenticated user and saves them in the session so they're authenticated in the next request.
 
-!!! tip
+!!! note
     The session cookie is not set to `secure` and `httpOnly` by default. Check Vapor's [Session API](../advanced/sessions.md#configuration) how to configure cookies.
 
 ### Protecting Routes

--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -749,7 +749,7 @@ These middlewares do the following:
 * the session authenticator takes the session and see if there is an authenticated user for that session. If so, the middleware authenticates the request. In the response, the session authenticator sees if the request has an authenticated user and saves them in the session so they're authenticated in the next request.
 
 !!! note
-    The session cookie is not set to `secure` and `httpOnly` by default. Check Vapor's [Session API](../advanced/sessions.md#configuration) how to configure cookies.
+    The session cookie is not set to `secure` and `httpOnly` by default. Check Vapor's [Session API](../advanced/sessions.md#configuration) for more information on how to configure cookies.
 
 ### Protecting Routes
 


### PR DESCRIPTION
This PR adds a small note about session cookie not being set to `secure` and `httpOnly` by default. This was something that I randomly noticed when I was figuring out how to set up authentication and I thought this might be a helpful note to others.
