### PR TITLE
Make custom Leaf tag examples complete

### DIFF
--- a/docs/leaf/custom-tags.md
+++ b/docs/leaf/custom-tags.md
@@ -4,13 +4,15 @@ You can create custom Leaf tags using the [`LeafTag`](https://api.vapor.codes/le
 
 To demonstrate this, let's take a look at creating a custom tag `#now` that prints the current timestamp. The tag will also support a single, optional parameter for specifying the date format.
 
+!!! tip
+	If your custom tag renders HTML you should conform your custom tag to `UnsafeUnescapedLeafTag` so the HTML is not escaped. Remember to check or sanitize any user input.
+
 ## `LeafTag`
 
 First create a class called `NowTag` and conform it to `LeafTag`.
 
 ```swift
 struct NowTag: LeafTag {
-    
     func render(_ ctx: LeafContext) throws -> LeafData {
         ...
     }
@@ -20,28 +22,31 @@ struct NowTag: LeafTag {
 Now let's implement the `render(_:)` method. The `LeafContext` context passed to this method has everything we should need.
 
 ```swift
-struct NowTagError: Error {}
+enum NowTagError: Error {
+    case invalidFormatParameter
+    case tooManyParameters
+}
 
-func render(_ ctx: LeafContext) throws -> LeafData {
-    let formatter = DateFormatter()
-    switch ctx.parameters.count {
-    case 0: formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-    case 1:
-	     guard let string = ctx.parameters[0].string else {
-	         throw NowTagError()
-	     }
-	     formatter.dateFormat = string
-    default:
-	     throw NowTagError()
-	 }
+struct NowTag: LeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
+        let formatter = DateFormatter()
+        switch ctx.parameters.count {
+        case 0: formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        case 1:
+            guard let string = ctx.parameters[0].string else {
+                throw NowTagError.invalidFormatParameter
+            }
+
+            formatter.dateFormat = string
+        default:
+            throw NowTagError.tooManyParameters
+	    }
     
-    let dateAsString = formatter.string(from: Date())
-    return LeafData.string(dateAsString)
+        let dateAsString = formatter.string(from: Date())
+        return LeafData.string(dateAsString)
+    }
 }
 ```
-
-!!! tip
-	If your custom tag renders HTML you should conform your custom tag to `UnsafeUnescapedLeafTag` so the HTML is not escaped. Remember to check or sanitize any user input.
 
 ## Configure Tag
 
@@ -73,15 +78,17 @@ To do see how to use this, let's implement a simple hello tag using both propert
 We can access the first parameter that would contain the name.
 
 ```swift
-struct HelloTagError: Error {}
+enum HelloTagError: Error {
+    case missingNameParameter
+}
 
-public func render(_ ctx: LeafContext) throws -> LeafData {
-
+struct HelloTag: UnsafeUnescapedLeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
         guard let name = ctx.parameters[0].string else {
-            throw HelloTagError()
+            throw HelloTagError.missingNameParameter
         }
 
-        return LeafData.string("<p>Hello \(name)</p>'")
+        return LeafData.string("<p>Hello \(name)</p>")
     }
 }
 ```
@@ -95,15 +102,17 @@ public func render(_ ctx: LeafContext) throws -> LeafData {
 We can access the name value by using the "name" key inside the data property.
 
 ```swift
-struct HelloTagError: Error {}
+enum HelloTagError: Error {
+    case nameNotFound
+}
 
-public func render(_ ctx: LeafContext) throws -> LeafData {
-
+struct HelloTag: UnsafeUnescapedLeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
         guard let name = ctx.data["name"]?.string else {
-            throw HelloTagError()
+            throw HelloTagError.nameNotFound
         }
 
-        return LeafData.string("<p>Hello \(name)</p>'")
+        return LeafData.string("<p>Hello \(name)</p>")
     }
 }
 ```
@@ -115,5 +124,5 @@ public func render(_ ctx: LeafContext) throws -> LeafData {
 _Controller_:
 
 ```swift
-return req.view.render("home", ["name": "John"])
+return try await req.view.render("home", ["name": "John"])
 ```

--- a/docs/leaf/custom-tags.nl.md
+++ b/docs/leaf/custom-tags.nl.md
@@ -4,13 +4,15 @@ U kunt aangepaste Leaf tags maken met het [`LeafTag`](https://api.vapor.codes/le
 
 Om dit te demonstreren, laten we eens kijken naar het maken van een aangepaste tag `#now` die de huidige tijdstempel afdrukt. De tag ondersteunt ook een enkele, optionele parameter voor het specificeren van het datumformaat.
 
+!!! tip
+	Als je aangepaste tag HTML rendert, moet je je tag conformeren aan `UnsafeUnescapedLeafTag` zodat de HTML niet ge-escaped wordt. Vergeet niet om alle gebruikersinvoer te controleren of te zuiveren.
+
 ## `LeafTag`
 
 Maak eerst een klasse genaamd `NowTag` en conformeer deze aan `LeafTag`.
 
 ```swift
 struct NowTag: LeafTag {
-    
     func render(_ ctx: LeafContext) throws -> LeafData {
         ...
     }
@@ -20,26 +22,31 @@ struct NowTag: LeafTag {
 Laten we nu de `render(_:)` methode implementeren. De `LeafContext` context die aan deze methode wordt doorgegeven heeft alles wat we nodig zouden moeten hebben.
 
 ```swift
-struct NowTagError: Error {}
-
-let formatter = DateFormatter()
-switch ctx.parameters.count {
-case 0: formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-case 1:
-    guard let string = ctx.parameters[0].string else {
-        throw NowTagError()
-    }
-    formatter.dateFormat = string
-default:
-    throw NowTagError()
+enum NowTagError: Error {
+    case invalidFormatParameter
+    case tooManyParameters
 }
 
-let dateAsString = formatter.string(from: Date())
-return LeafData.string(dateAsString)
-```
+struct NowTag: LeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
+        let formatter = DateFormatter()
+        switch ctx.parameters.count {
+        case 0: formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        case 1:
+            guard let string = ctx.parameters[0].string else {
+                throw NowTagError.invalidFormatParameter
+            }
 
-!!! tip
-	Als je aangepaste tag HTML rendert, moet je je tag conformeren aan `UnsafeUnescapedLeafTag` zodat de HTML niet ge-escaped wordt. Vergeet niet om alle gebruikersinvoer te controleren of te zuiveren.
+            formatter.dateFormat = string
+        default:
+            throw NowTagError.tooManyParameters
+	    }
+    
+        let dateAsString = formatter.string(from: Date())
+        return LeafData.string(dateAsString)
+    }
+}
+```
 
 ## Tag Configureren
 
@@ -71,15 +78,17 @@ Om te zien hoe dit te gebruiken, laten we een eenvoudige "hello" tag implementer
 We hebben toegang tot de eerste parameter die de naam zou bevatten.
 
 ```swift
-struct HelloTagError: Error {}
+enum HelloTagError: Error {
+    case missingNameParameter
+}
 
-public func render(_ ctx: LeafContext) throws -> LeafData {
-
+struct HelloTag: UnsafeUnescapedLeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
         guard let name = ctx.parameters[0].string else {
-            throw HelloTagError()
+            throw HelloTagError.missingNameParameter
         }
 
-        return LeafData.string("<p>Hello \(name)</p>'")
+        return LeafData.string("<p>Hello \(name)</p>")
     }
 }
 ```
@@ -93,15 +102,17 @@ public func render(_ ctx: LeafContext) throws -> LeafData {
 We kunnen de waarde van de naam benaderen door de sleutel "name" te gebruiken in de data property.
 
 ```swift
-struct HelloTagError: Error {}
+enum HelloTagError: Error {
+    case nameNotFound
+}
 
-public func render(_ ctx: LeafContext) throws -> LeafData {
-
+struct HelloTag: UnsafeUnescapedLeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
         guard let name = ctx.data["name"]?.string else {
-            throw HelloTagError()
+            throw HelloTagError.nameNotFound
         }
 
-        return LeafData.string("<p>Hello \(name)</p>'")
+        return LeafData.string("<p>Hello \(name)</p>")
     }
 }
 ```
@@ -113,5 +124,5 @@ public func render(_ ctx: LeafContext) throws -> LeafData {
 _Controller_:
 
 ```swift
-return req.view.render("home", ["name": "John"])
+return try await req.view.render("home", ["name": "John"])
 ```

--- a/docs/leaf/custom-tags.zh.md
+++ b/docs/leaf/custom-tags.zh.md
@@ -4,13 +4,15 @@
 
 为了演示这一点，让我们看看创建一个 `#now` 标签来打印当前时间戳。标签还支持一个可选参数来指定日期格式。
 
+!!! tip "建议" 
+    如果你的自定义标签用来渲染 HTML，你应该使你的自定义标记符合 `UnsafeUnescapedLeafTag`，这样 HTML 就不会被转义。别忘了检查或清除用户的任何输入。
+
 ## `LeafTag`
 
 首先创建一个名为 `NowTag` 的类并遵循 `LeafTag` 协议。
 
 ```swift
 struct NowTag: LeafTag {
-    
     func render(_ ctx: LeafContext) throws -> LeafData {
         ...
     }
@@ -20,28 +22,31 @@ struct NowTag: LeafTag {
 现在我们来实现 `render(_:)` 方法。传递给该方法的 `LeafContext` 参数包含了我们需要的所有内容。
 
 ```swift
-struct NowTagError: Error {}
+enum NowTagError: Error {
+    case invalidFormatParameter
+    case tooManyParameters
+}
 
-func render(_ ctx: LeafContext) throws -> LeafData {
-    let formatter = DateFormatter()
-    switch ctx.parameters.count {
-    case 0: formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-    case 1:
-	     guard let string = ctx.parameters[0].string else {
-	         throw NowTagError()
-	     }
-	     formatter.dateFormat = string
-    default:
-	     throw NowTagError()
-	 }
+struct NowTag: LeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
+        let formatter = DateFormatter()
+        switch ctx.parameters.count {
+        case 0: formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        case 1:
+            guard let string = ctx.parameters[0].string else {
+                throw NowTagError.invalidFormatParameter
+            }
+
+            formatter.dateFormat = string
+        default:
+            throw NowTagError.tooManyParameters
+	    }
     
-    let dateAsString = formatter.string(from: Date())
-    return LeafData.string(dateAsString)
+        let dateAsString = formatter.string(from: Date())
+        return LeafData.string(dateAsString)
+    }
 }
 ```
-
-!!! tip "建议" 
-    如果你的自定义标签用来渲染 HTML，你应该使你的自定义标记符合 `UnsafeUnescapedLeafTag`，这样 HTML 就不会被转义。别忘了检查或清除用户的任何输入。
 
 ## 配置标签
 
@@ -74,15 +79,17 @@ The time is #now()
 我们可以访问包含名称的第一个参数。
 
 ```swift
-struct HelloTagError: Error {}
+enum HelloTagError: Error {
+    case missingNameParameter
+}
 
-public func render(_ ctx: LeafContext) throws -> LeafData {
-
+struct HelloTag: UnsafeUnescapedLeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
         guard let name = ctx.parameters[0].string else {
-            throw HelloTagError()
+            throw HelloTagError.missingNameParameter
         }
 
-        return LeafData.string("<p>Hello \(name)</p>'")
+        return LeafData.string("<p>Hello \(name)</p>")
     }
 }
 ```
@@ -96,15 +103,17 @@ public func render(_ ctx: LeafContext) throws -> LeafData {
 我们可以通过使用 data 属性中的 ”name“ 键来访问 name 值。
 
 ```swift
-struct HelloTagError: Error {}
+enum HelloTagError: Error {
+    case nameNotFound
+}
 
-public func render(_ ctx: LeafContext) throws -> LeafData {
-
+struct HelloTag: UnsafeUnescapedLeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
         guard let name = ctx.data["name"]?.string else {
-            throw HelloTagError()
+            throw HelloTagError.nameNotFound
         }
 
-        return LeafData.string("<p>Hello \(name)</p>'")
+        return LeafData.string("<p>Hello \(name)</p>")
     }
 }
 ```
@@ -116,5 +125,5 @@ public func render(_ ctx: LeafContext) throws -> LeafData {
 控制器：
 
 ```swift
-return req.view.render("home", ["name": "John"])
+return try await req.view.render("home", ["name": "John"])
 ```

--- a/docs/redis/overview.md
+++ b/docs/redis/overview.md
@@ -32,7 +32,7 @@ targets: [
 
 ## Configure
 
-Vapor employs a pooling strategy for [`RedisConnection`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redisconnection) instances, and there are several options to configure individual connections as well as the pools themselves.
+Vapor employs a pooling strategy for [`RedisConnection`](https://swiftpackageindex.com/mordil/redistack/1.3.2/documentation/redistack/redisconnection) instances, and there are several options to configure individual connections as well as the pools themselves.
 
 The bare minimum required for configuring Redis is to provide a URL to connect to:
 
@@ -102,7 +102,7 @@ This option determines the behavior of how the maximum connection count is maint
 
 ## Sending a Command
 
-You can send commands using the `.redis` property on any [`Application`](https://api.vapor.codes/vapor/main/Vapor/Application/) or [`Request`](https://api.vapor.codes/vapor/main/Vapor/Request/) instance, which will give you access to a [`RedisClient`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redisclient).
+You can send commands using the `.redis` property on any [`Application`](https://api.vapor.codes/vapor/main/Vapor/Application/) or [`Request`](https://api.vapor.codes/vapor/main/Vapor/Request/) instance, which will give you access to a [`RedisClient`](https://swiftpackageindex.com/mordil/redistack/1.3.2/documentation/redistack/redisclient).
 
 Any `RedisClient` has several extensions for all of the various [Redis commands](https://redis.io/commands).
 
@@ -148,7 +148,7 @@ There is a defined lifecycle to a subscription:
 1. **message**: invoked 0+ times as messages are published to the subscribed channels
 1. **unsubscribe**: invoked once when the subscription ends, either by request or the connection being lost
 
-When you create a subscription, you must provide at least a [`messageReceiver`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redissubscriptionmessagereceiver) to handle all messages that are published by the subscribed channel.
+When you create a subscription, you must provide at least a [`messageReceiver`](https://swiftpackageindex.com/mordil/redistack/1.3.2/documentation/redistack/redissubscriptionmessagereceiver) to handle all messages that are published by the subscribed channel.
 
 You can optionally provide a `RedisSubscriptionChangeHandler` for `onSubscribe` and `onUnsubscribe` to handle their respective lifecycle events.
 

--- a/docs/redis/overview.nl.md
+++ b/docs/redis/overview.nl.md
@@ -32,7 +32,7 @@ targets: [
 
 ## Configuratie
 
-Vapor gebruikt een pooling strategie voor [`RedisConnection`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redisconnection) instanties, en er zijn verschillende opties om zowel individuele verbindingen als de pools zelf te configureren.
+Vapor gebruikt een pooling strategie voor [`RedisConnection`](https://swiftpackageindex.com/mordil/redistack/1.3.2/documentation/redistack/redisconnection) instanties, en er zijn verschillende opties om zowel individuele verbindingen als de pools zelf te configureren.
 
 Het absolute minimum dat nodig is voor het configureren van Redis is het opgeven van een URL om verbinding mee te maken:
 
@@ -102,7 +102,7 @@ Deze optie bepaalt het gedrag van hoe het maximum aantal verbindingen wordt bijg
 
 ## Een commando versturen
 
-Je kunt commando's sturen met de `.redis` eigenschap op elke [`Application`](https://api.vapor.codes/vapor/main/Vapor/Application/) of [`Request`](https://api.vapor.codes/vapor/main/Vapor/Request/) instantie, die je toegang geeft tot een [`RedisClient`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redisclient).
+Je kunt commando's sturen met de `.redis` eigenschap op elke [`Application`](https://api.vapor.codes/vapor/main/Vapor/Application/) of [`Request`](https://api.vapor.codes/vapor/main/Vapor/Request/) instantie, die je toegang geeft tot een [`RedisClient`](https://swiftpackageindex.com/mordil/redistack/1.3.2/documentation/redistack/redisclient).
 
 Elke `RedisClient` heeft verschillende extensies voor alle verschillende [Redis commando's](https://redis.io/commands).
 
@@ -148,7 +148,7 @@ Er is een bepaalde levenscyclus voor een abonnement:
 1. **message**: 0+ keer aangeroepen als berichten worden gepubliceerd in de geabonneerde kanalen
 1. **unsubscribe**: eenmaal aangeroepen wanneer het abonnement eindigt, hetzij door een verzoek, hetzij doordat de verbinding wordt verbroken
 
-Wanneer je een abonnement aanmaakt, moet je minstens een [`messageReceiver`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redissubscriptionmessagereceiver) voorzien om alle berichten te behandelen die gepubliceerd worden door het geabonneerde kanaal.
+Wanneer je een abonnement aanmaakt, moet je minstens een [`messageReceiver`](https://swiftpackageindex.com/mordil/redistack/1.3.2/documentation/redistack/redissubscriptionmessagereceiver) voorzien om alle berichten te behandelen die gepubliceerd worden door het geabonneerde kanaal.
 
 U kunt optioneel een `RedisSubscriptionChangeHandler` opgeven voor `onSubscribe` en `onUnsubscribe` om hun respectievelijke lifecycle events af te handelen.
 

--- a/docs/redis/overview.zh.md
+++ b/docs/redis/overview.zh.md
@@ -32,7 +32,7 @@ targets: [
 
 ## 配置
 
-Vapor 对 [`RedisConnection`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redisconnection) 实例采用池化策略，并且有几个选项可以配置单个连接以及池本身。
+Vapor 对 [`RedisConnection`](https://swiftpackageindex.com/mordil/redistack/1.3.2/documentation/redistack/redisconnection) 实例采用池化策略，并且有几个选项可以配置单个连接以及池本身。
 
 配置 Redis 的最低要求是提供一个 URL 来连接：
 
@@ -102,7 +102,7 @@ let serverAddresses: [SocketAddress] = [
 
 ## 发送命令
 
-你可以使用  [`Application`](https://api.vapor.codes/vapor/main/Vapor/Application/) 或 [`Request`](https://api.vapor.codes/vapor/main/Vapor/Request/) 实例上的 `.redis` 属性发送命令，这使得你可以访问 [`RedisClient`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redisclient)。
+你可以使用  [`Application`](https://api.vapor.codes/vapor/main/Vapor/Application/) 或 [`Request`](https://api.vapor.codes/vapor/main/Vapor/Request/) 实例上的 `.redis` 属性发送命令，这使得你可以访问 [`RedisClient`](https://swiftpackageindex.com/mordil/redistack/1.3.2/documentation/redistack/redisclient)。
 
 对于各别的 [Redis 命令](https://redis.io/commands)，`RedisClient` 都有其对应的扩展。
 
@@ -148,7 +148,7 @@ Redis 支持进入[发布/订阅模式](https://redis.io/topics/pubsub)，其中
 1. **message**：在消息发布到订阅频道时调用 0+ 次
 1. **unsubscribe**：订阅结束时调用一次，无论是通过请求还是连接丢失
 
-创建订阅时，你必须至少提供一个 [`messageReceiver`](https://swiftpackageindex.com/mordil/redistack/master/documentation/redistack/redissubscriptionmessagereceiver) 来处理订阅频道发布的所有消息。
+创建订阅时，你必须至少提供一个 [`messageReceiver`](https://swiftpackageindex.com/mordil/redistack/1.3.2/documentation/redistack/redissubscriptionmessagereceiver) 来处理订阅频道发布的所有消息。
 
 你可以选择为 `onSubscribe` 和 `onUnsubscribe`  提供一个 `RedisSubscriptionChangeHandler` 来处理它们各自的生命周期事件。
 


### PR DESCRIPTION
As reported in [vapor/vapor#2942](https://github.com/vapor/vapor/issues/2942), UnsafeUnescapedLeafTag is going unnoticed.

To bring more attention to it, I:
- moved the tip to the top section in all languages,
- updated the HelloTag to use the protocol (since it was rendering garbage since the LeafKit update)
- and arranged all code samples to a common structure so they are now directly copiable.