### PR TITLE
Fix getting started URLs by adding /hello

### DIFF
--- a/docs/getting-started/hello-world.de.md
+++ b/docs/getting-started/hello-world.de.md
@@ -53,6 +53,6 @@ Bei der Erstausführung werden die Paketverweise nachgeladen. Dementsprechend ka
 
 ## Aufruf im Browser
 
-Rufe die Seite über den Link <a href="http://localhost:8080/hello" target="_blank">localhost:8080/hello</a> oder <a href="http://127.0.0.1:8080" target="_blank">http://127.0.0.1:8080</a> im Browser auf. Als Ergebnis sollte "Hello World" im Browser erscheinen.
+Rufe die Seite über den Link <a href="http://localhost:8080/hello" target="_blank">localhost:8080/hello</a> oder <a href="http://127.0.0.1:8080/hello" target="_blank">http://127.0.0.1:8080/hello</a> im Browser auf. Als Ergebnis sollte "Hello World" im Browser erscheinen.
 
 Das wars! Geschafft! Gratulation zur ersten Vapor-Anwendung. 🎉

--- a/docs/getting-started/hello-world.md
+++ b/docs/getting-started/hello-world.md
@@ -68,7 +68,7 @@ That will build and run the project. The first time you run this it will take so
 
 ## Visit Localhost
 
-Open your web browser, and visit <a href="http://localhost:8080/hello" target="_blank">localhost:8080/hello</a> or <a href="http://127.0.0.1:8080" target="_blank">http://127.0.0.1:8080</a>
+Open your web browser, and visit <a href="http://localhost:8080/hello" target="_blank">localhost:8080/hello</a> or <a href="http://127.0.0.1:8080/hello" target="_blank">http://127.0.0.1:8080/hello</a>
 
 You should see the following page.
 

--- a/docs/getting-started/hello-world.nl.md
+++ b/docs/getting-started/hello-world.nl.md
@@ -65,7 +65,7 @@ Dat zal het project bouwen en uitvoeren. De eerste keer dat je dit uitvoert zal 
 
 ## Bezoek Localhost
 
-Open je webbrowser, en bezoek <a href="http://localhost:8080/hello" target="_blank">localhost:8080/hello</a> of <a href="http://127.0.0.1:8080" target="_blank">http://127.0.0.1:8080</a>
+Open je webbrowser, en bezoek <a href="http://localhost:8080/hello" target="_blank">localhost:8080/hello</a> of <a href="http://127.0.0.1:8080/hello" target="_blank">http://127.0.0.1:8080/hello</a>
 
 Je zou de volgende pagina moeten zien.
 

--- a/docs/getting-started/hello-world.zh.md
+++ b/docs/getting-started/hello-world.zh.md
@@ -66,7 +66,7 @@ swift run
 
 ## 访问 Localhost
 
-打开你的浏览器，然后访问 <a href="http://localhost:8080/hello" target="_blank">localhost:8080/hello</a> 或者 <a href="http://127.0.0.1:8080" target="_blank">http://127.0.0.1:8080</a>
+打开你的浏览器，然后访问 <a href="http://localhost:8080/hello" target="_blank">localhost:8080/hello</a> 或者 <a href="http://127.0.0.1:8080/hello" target="_blank">http://127.0.0.1:8080/hello</a>
 
 你将看见以下页面
 


### PR DESCRIPTION
http://127.0.0.1:8080 gave me an error message in the browser:
`{"error":true,"reason":"No template found for index"}`
If you add `/hello` in both cases, everything works.