### PR TITLE
Update Heroku documentation to deploy a Postgres database

### DIFF
--- a/docs/deploy/heroku.md
+++ b/docs/deploy/heroku.md
@@ -200,9 +200,14 @@ The Heroku Postgres addon [requires](https://devcenter.heroku.com/changelog-item
 The following snippet shows how to achieve both:
 
 ```swift
-if let databaseURL = Environment.get("DATABASE_URL"), var postgresConfig = PostgresConfiguration(url: databaseURL) {
-    postgresConfig.tlsConfiguration = .makeClientConfiguration()
-    postgresConfig.tlsConfiguration?.certificateVerification = .none
+if let databaseURL = Environment.get("DATABASE_URL") {
+    var tlsConfig: TLSConfiguration = .makeClientConfiguration()
+    tlsConfig.certificateVerification = .none
+    let nioSSLContext = try NIOSSLContext(configuration: tlsConfig)
+
+    var postgresConfig = try SQLPostgresConfiguration(url: databaseURL)
+    postgresConfig.coreConfiguration.tls = .require(nioSSLContext)
+
     app.databases.use(.postgres(configuration: postgresConfig), as: .psql)
 } else {
     // ...

--- a/docs/deploy/heroku.nl.md
+++ b/docs/deploy/heroku.nl.md
@@ -199,9 +199,14 @@ De Heroku Postgres addon [vereist](https://devcenter.heroku.com/changelog-items/
 Het volgende fragment laat zien hoe beide bereikt kunnen worden:
 
 ```swift
-if let databaseURL = Environment.get("DATABASE_URL"), var postgresConfig = PostgresConfiguration(url: databaseURL) {
-    postgresConfig.tlsConfiguration = .makeClientConfiguration()
-    postgresConfig.tlsConfiguration?.certificateVerification = .none
+if let databaseURL = Environment.get("DATABASE_URL") {
+    var tlsConfig: TLSConfiguration = .makeClientConfiguration()
+    tlsConfig.certificateVerification = .none
+    let nioSSLContext = try NIOSSLContext(configuration: tlsConfig)
+
+    var postgresConfig = try SQLPostgresConfiguration(url: databaseURL)
+    postgresConfig.coreConfiguration.tls = .require(nioSSLContext)
+
     app.databases.use(.postgres(configuration: postgresConfig), as: .psql)
 } else {
     // ...

--- a/docs/deploy/heroku.zh.md
+++ b/docs/deploy/heroku.zh.md
@@ -198,9 +198,14 @@ DATABASE_URL: postgres://cybntsgadydqzm:2d9dc7f6d964f4750da1518ad71hag2ba729cd45
 
 ```swift
 if let databaseURL = Environment.get("DATABASE_URL") {
-    app.databases.use(try .postgres(
-        url: databaseURL
-    ), as: .psql)
+    var tlsConfig: TLSConfiguration = .makeClientConfiguration()
+    tlsConfig.certificateVerification = .none
+    let nioSSLContext = try NIOSSLContext(configuration: tlsConfig)
+
+    var postgresConfig = try SQLPostgresConfiguration(url: databaseURL)
+    postgresConfig.coreConfiguration.tls = .require(nioSSLContext)
+
+    app.databases.use(.postgres(configuration: postgresConfig), as: .psql)
 } else {
     // ...
 }


### PR DESCRIPTION
This Pull Request is made following a [thread on the Vapor Discord Channel](https://discord.com/channels/431917998102675485/684159753189982218/1114122387978452992).

As Vapor update to 4.77.0, the code snippet in the documentation was showing warning for the deprecated code. 

Warning shown: 
- `'PostgresConfiguration' is deprecated: Use `SQLPostgresConfiguration` instead.`
- `'postgres(configuration:maxConnectionsPerEventLoop:connectionPoolTimeout:encoder:decoder:sqlLogLevel:)' is deprecated: Use `.postgres(configuration:maxConnectionsPerEventLoop:connectionPoolTimeout:encodingContext:decodingContext:sqlLogLevel:)` instead.`

Code update: (Tested as I deployed my own code to Heroku). 
- The configuration for a Postgres database is now made with `SQLPostgresConfiguration` in place of `PostgresConfiguration`.
- The certificate verification is made using `TLSConfiguration`. 
