### PR TITLE
Correct issue template to tag translators correctly

### DIFF
--- a/.github/workflows/translation-issue-template.md
+++ b/.github/workflows/translation-issue-template.md
@@ -11,4 +11,4 @@ Languages:
 - [ ] Dutch
 - [ ] Italian
 
-Assigned to @vapor/translations - please submit a PR with the relevant updates and check the box once merged. Please ensure you tag your PR with the `translation-update` so it doesn't create a new issue!
+Assigned to @vapor/translators - please submit a PR with the relevant updates and check the box once merged. Please ensure you tag your PR with the `translation-update` so it doesn't create a new issue!


### PR DESCRIPTION
This updates the GH actions issue template to tag `@vapor/translators` correctly rather then `@vapor/translations`