### PR TITLE
Add Spanish translation for basics/logging and basics/environment

### DIFF
--- a/docs/basics/environment.es.md
+++ b/docs/basics/environment.es.md
@@ -65,7 +65,7 @@ Al ejecutar tu app en Xcode, puedes estableces variables de entorno editando el 
 
 ## .env (dotenv)
 
-Los fichero Dotenv contienen una lista de pares clave-valor para ser cargados automáticamente en el entorno. Estos ficheros facilitan la configuración de variables de entorno sin necesidad de establecerlas manualmente.
+Los fichero dotenv contienen una lista de pares clave-valor para ser cargados automáticamente en el entorno. Estos ficheros facilitan la configuración de variables de entorno sin necesidad de establecerlas manualmente.
 
 Vapor buscará ficheros dotenv en el directorio de trabajo actual (current working directory). Si estás usando Xcode, asegúrate de configurar el directorio de trabajo (working directory) editando el esquema (scheme) de la `App`.
 

--- a/docs/basics/environment.es.md
+++ b/docs/basics/environment.es.md
@@ -1,6 +1,6 @@
 # Entorno
 
-La API de entorno (Environment) de Vapor te ayuda a configurar tu app de manera dinámica. Por defecto, tu app usará el entorno `development`. Puedes definir otros entornos útiles como `production` o `staging` y cambiar la configuración de la app para cada caso. Tambibén puedes cargar variables desde el entorno del proceso o desde ficheros `.env` (dotenv) dependiendo de tus necesidades.
+La API de entorno (Environment) de Vapor te ayuda a configurar tu app de manera dinámica. Por defecto, tu app usará el entorno `development`. Puedes definir otros entornos útiles como `production` o `staging` y cambiar la configuración de la app para cada caso. También puedes cargar variables desde el entorno del proceso o desde ficheros `.env` (dotenv) dependiendo de tus necesidades.
 
 Para acceder al entorno actual, usa `app.environment`. Puedes hacer un switch de esta propiedad en `configure(_:)` para ejecutar distintas lógicas de configuración. 
 

--- a/docs/basics/environment.es.md
+++ b/docs/basics/environment.es.md
@@ -1,0 +1,144 @@
+# Entorno
+
+La API de entorno (Environment) de Vapor te ayuda a configurar tu app de manera dinámica. Por defecto, tu app usará el entorno `development`. Puedes definir otros entornos útiles como `production` o `staging` y cambiar la configuración de la app para cada caso. Tambibén puedes cargar variables desde el entorno del proceso o desde ficheros `.env` (dotenv) dependiendo de tus necesidades.
+
+Para acceder al entorno actual, usa `app.environment`. Puedes hacer un switch de esta propiedad en `configure(_:)` para ejecutar distintas lógicas de configuración. 
+
+```swift
+switch app.environment {
+case .production:
+    app.databases.use(....)
+default:
+    app.databases.use(...)
+}
+```
+
+## Cambiando de Entorno
+
+Por defecto, tu app se ejecutará en el entorno `development`. Puedes cambiar esto pasando el argumento (flag) `--env` (`-e`) durante el arranque de la app.
+
+```swift
+swift run App serve --env production
+```
+
+Vapor incluye los siguientes entornos:
+
+|nombre|abreviación|descripción|
+|-|-|-|
+|production|prod|Distribuido a tus usuarios.|
+|development|dev|Desarrollo local.|
+|testing|test|Para test unitario (unit testing).|
+
+!!! info "Información"
+    El entorno `production` usará el nivel de registro `notice` por defecto si no se especifica otro. El resto de entornos usarán `info` por defecto. 
+
+Puedes pasar tanto el nombre entero como la abreviación del nombre en el argumento `--env` (`-e`).
+
+```swift
+swift run App serve -e prod
+```
+
+## Variables de Proceso
+
+`Environment` ofrece una API simple basada en cadenas (string) para acceder a las variables de entorno de los procesos.
+
+```swift
+let foo = Environment.get("FOO")
+print(foo) // String?
+```
+
+Además del método `get`, `Environment` ofrece una API de búsqueda dinñamica de miembros (dynamic member lookup) mediante `process`.
+
+```swift
+let foo = Environment.process.FOO
+print(foo) // String?
+```
+
+Al ejecutar tu app en el terminal, puedes estableces variables de entorno usando `export`. 
+
+```sh
+export FOO=BAR
+swift run App serve
+```
+
+Al ejecutar tu app en Xcode, puedes estableces variables de entorno editando el esquema (scheme) de la `App`.
+
+## .env (dotenv)
+
+Los fichero Dotenv contienen una lista de pares clave-valor para ser cargados automáticamente en el entorno. Estos ficheros facilitan la configuración de variables de entorno sin necesidad de establecerlas manualmente.
+
+Vapor buscará ficheros dotenv en el directorio de trabajo actual (current working directory). Si estás usando Xcode, asegúrate de configurar el directorio de trabajo (working directory) editando el esquema (scheme) de la `App`.
+
+Asume que el siguiente fichero `.env` está en la carpeta raíz de tu projecto:
+
+```sh
+FOO=BAR
+```
+
+Cuando tu aplicación arranque, podrás acceder a los contenidos de este fichero como si fueran otras variables de entorno de proceso.
+
+```swift
+let foo = Environment.get("FOO")
+print(foo) // String?
+```
+
+!!! info "Información"
+    Las variables especificadas en ficheros `.env` no sobrescribirán variables ya existentes en el entorno de proceso. 
+
+Junto con `.env`, Vapor también tratará de cargar un fichero dotenv para el entorno actual. Por ejemplo, en el entorno `development`, Vapor cargará `.env.development`. Cualquier valor en el fichero de entorno especificado tendrá prioridad frente al fichero `.env` general.
+
+Un típico patrón a seguir en los proyectos es incluir un fichero `.env` como una plantilla con valores predeterminados. Los ficheros de entorno específico pueden ser ignorados con este patrón de `.gitignore`:
+
+```gitignore
+.env.*
+```
+
+Cuando el proyecto es clonado a otra computadora, el fichero `.env` de plantilla puede ser copiado, para después insertar los valores correctos. 
+
+```sh
+cp .env .env.development
+vim .env.development
+```
+
+!!! warning "Aviso"
+    Los ficheros dotenv con información sensible como contraseñas no deberían añadirse en los commits del control de versiones.
+
+Si estás teniendo dificultades en la carga de ficheros dotenv, prueba a habilitar el registro de depuración (debug logging) con `--log debug` para obtener más información. 
+
+## Entornos Personalizados
+
+Para definir un nombre de entorno personalizado, realiza una extensión de `Environment`.
+
+```swift
+extension Environment {
+    static var staging: Environment {
+        .custom(name: "staging")
+    }
+}
+```
+
+El entorno de la aplicación es establecido normalmente en `entrypoint.swift` usando `Environment.detect()`.
+
+```swift
+@main
+enum Entrypoint {
+    static func main() async throws {
+        var env = try Environment.detect()
+        try LoggingSystem.bootstrap(from: &env)
+        
+        let app = Application(env)
+        defer { app.shutdown() }
+        
+        try await configure(app)
+        try await app.runFromAsyncMainEntrypoint()
+    }
+}
+```
+
+El método `detect` usa los argumentos de línea de comandos del proceso y analiza el argumento (flag) `--env` automáticamente. Puedes sobrescribir este comportamiento inicializando un struct `Environment` personalizado.
+
+```swift
+let env = Environment(name: "testing", arguments: ["vapor"])
+```
+
+El array de argumentos debe contener al menos uno que represente el nombre del ejecutable. Se pueden suministrar más argumentos para simular el paso de argumentos mediante línea de comandos. Esto es especialmente útil para testing.

--- a/docs/basics/environment.es.md
+++ b/docs/basics/environment.es.md
@@ -47,7 +47,7 @@ let foo = Environment.get("FOO")
 print(foo) // String?
 ```
 
-Además del método `get`, `Environment` ofrece una API de búsqueda dinñamica de miembros (dynamic member lookup) mediante `process`.
+Además del método `get`, `Environment` ofrece una API de búsqueda dinámica de miembros (dynamic member lookup) mediante `process`.
 
 ```swift
 let foo = Environment.process.FOO

--- a/docs/basics/environment.es.md
+++ b/docs/basics/environment.es.md
@@ -101,7 +101,7 @@ vim .env.development
 ```
 
 !!! warning "Aviso"
-    Los ficheros dotenv con información sensible como contraseñas no deberían añadirse en los commits del control de versiones.
+    Los ficheros dotenv con información sensible como contraseñas no deben añadirse en los commits del control de versiones.
 
 Si estás teniendo dificultades en la carga de ficheros dotenv, prueba a habilitar el registro de depuración (debug logging) con `--log debug` para obtener más información. 
 

--- a/docs/basics/logging.es.md
+++ b/docs/basics/logging.es.md
@@ -1,0 +1,109 @@
+# Logging (Registro)
+
+La API de logging (registro) de Vapor está hecha sobre [SwiftLog](https://github.com/apple/swift-log). Esto implica que Vapor es compatible con todas las [implementaciones de backend](https://github.com/apple/swift-log#backends) de SwiftLog. 
+
+## Logger
+
+Las instancias de `Logger` son usadas para emitir mensajes de registro. Vapor proporciona varias formas sencillas de acceso a un logger (registrador).
+
+### Petición (Request)
+
+Cada `Request` entrante tiene un logger único que debes usar para cualquier registro específico de la propia petición.
+
+```swift
+app.get("hello") { req -> String in
+    req.logger.info("Hello, logs!")
+    return "Hello, world!"
+}
+```
+
+El logger de la petición incluye un UUID único que identifica la petición entrante para facilitar el seguimiento de los registros.
+
+```
+[ INFO ] Hello, logs! [request-id: C637065A-8CB0-4502-91DC-9B8615C5D315] (App/routes.swift:10)
+```
+
+!!! info "Información"
+	Los metadatos del logger solo se mostrarán en el nivel de registro de depuración (debug) o inferiores.
+
+### Aplicación
+
+Para los mensajes de registro durante el arranque y la configuración de la app, usa el logger de `Application`.
+
+```swift
+app.logger.info("Setting up migrations...")
+app.migrations.use(...)
+```
+
+### Logger Personalizado
+
+En situaciones donde no tengas acceso a `Application` o `Request`, puedes inicializar un nuevo `Logger`. 
+
+```swift
+let logger = Logger(label: "dev.logger.my")
+logger.info(...)
+```
+
+Si bien los loggers personalizados emitirán registros al backend de registro que tengas configurado, los registros no contendrán metadatos adicionales relevantes, como el UUID de la petición. Utiliza los loggers específicos de las petición o de la aplicación siempre que puedas. 
+
+## Nivel
+
+SwiftLog soporta una variedad de niveles de registro.
+
+|nombre|descripción|
+|-|-|
+|trace|Apropiado para mensajes que contengan información usada normalmente cuando se está trazando la ejecución de un programa.|
+|debug|Apropiado para mensajes que contengan información usada normalmente en procesos de debug de un programa.|
+|info|Apropiado para mensajes informativos.|
+|notice|Apropiado para condiciones que no sean errores pero puedan requerir un manejo especial.|
+|warning|Apropiado para mensajes que no sean condiciones de error pero más severos que un aviso.|
+|error|Apropiado para condiciones de error.|
+|critical|Apropiado para el manejo de condiciones críticas de error que requieran atención inmediata.|
+
+Cuando un mensaje `critical` es registrado, el backend de registro es libre de realizar operaciones más pesadas para capturar el estado del sistema, como la captura de rastros de pila (stack traces), para facilitar el proceso de depuración (debugging).
+
+Por defecto, Vapor usará en nivel de registro `info`. Cuando sea ejecutado en el entorno `production`, se usará `notice` para mejorar el rendimiento. 
+
+### Cambiando el nivel de registro
+
+Puedes cambiar el nivel de registro independientemente del modo de entorno para aumentar o disminuir la cantidad de registros producidos. 
+
+El primer método consiste en pasar la flag opcional `--log` cuando arranques tu aplicación.
+
+```sh
+swift run App serve --log debug
+```
+
+El segundo método consiste en establecer la variable de entorno `LOG_LEVEL`.
+
+```sh
+export LOG_LEVEL=debug
+swift run App serve
+```
+
+Ambos métodos pueden realizarse en Xcode editando el `App` scheme (esquema de la app).
+
+## Configuración
+
+SwiftLog se configura arrancando (bootstrapping) el `LoggingSystem` una vez por cada proceso. Los projectos de Vapor normalmente hacen esto en `entrypoint.swift`.
+
+```swift
+var env = try Environment.detect()
+try LoggingSystem.bootstrap(from: &env)
+```
+
+`bootstrap(from:)` es un método de ayuda (helper method) proporcionado por Vapor que configurará el handler de registros predeterminado en base a argumentos de línea de comandos y variables de entorno. El handler de registros predeterminado soporta la emisión de mensajes a la terminal con soporte de color ANSI. 
+
+### Handler Personalizado
+
+Puedes sobrescribir el handler de registros predeterminado de Vapor y registrar el tuyo propio.
+
+```swift
+import Logging
+
+LoggingSystem.bootstrap { label in
+    StreamLogHandler.standardOutput(label: label)
+}
+```
+
+ Todos los backend soportados por SwiftLog funcionarán con Vapor. Sin embargo, cambiar el nivel de registro con argumentos de línea de comandos y variables de entorno es compatible únicamente con el handler de registros predeterminado de Vapor.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -317,7 +317,7 @@ plugins:
           Validation: Validación
           Async: Async
           Logging: Logging
-          Environment: Ambiente
+          Environment: Entorno
           Errors: Errores
           Fluent: Fluent
           Overview: Presentación


### PR DESCRIPTION
Added Spanish translations for files `logging.md` and `environment` located in `basics`. Updated `mkdocks.yml`.
