### PR TITLE
Update Search Index Script for new languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can check it out by running `mkdocs serve` in the terminal. Once you are sat
 
 > NOTE: If a file isn't translated, it will just default to the default language file. So you don't have to translate everything all at once.
 
-Finally, you should add the new language to the [issue template](https://github.com/vapor/docs/blob/main/.github/workflows/translation-issue-template.md) to ensure that any future changes are applied to the new translation.
+Finally, you should add the new language to the [issue template](https://github.com/vapor/docs/blob/main/.github/workflows/translation-issue-template.md) to ensure that any future changes are applied to the new translation and to the [search index script](https://github.com/vapor/docs/blob/main/fixSearchIndex.swift) to ensure search works correctly.
 
 
   

--- a/fixSearchIndex.swift
+++ b/fixSearchIndex.swift
@@ -37,17 +37,22 @@ let searchIndex = try JSONDecoder().decode(SearchIndex.self, from: indexData)
 var newSearchIndex = searchIndex
 var searchIndexDocs = [SearchIndexDocs]()
 
+let knownLanguages = [
+        "en",
+        "de",
+        "es",
+        "fr",
+        "it",
+        "ko",
+        "nl",
+        "pl",
+        "zh",
+    ].map { "\($0)/" }
+
+
 for doc in newSearchIndex.docs {
-    if !doc.location.starts(with: "en/")
-      && !doc.location.starts(with: "de/")
-      && !doc.location.starts(with: "es/")
-      && !doc.location.starts(with: "fr/") 
-      && !doc.location.starts(with: "it/") 
-      && !doc.location.starts(with: "ko/") 
-      && !doc.location.starts(with: "nl/") 
-      && !doc.location.starts(with: "pl/") 
-      && !doc.location.starts(with: "zk/") {
-          searchIndexDocs.append(doc)
+    if !knownLanguages.contains(where: { doc.location.starts(with: $0) }) {
+        searchIndexDocs.append(doc)
     }
 }
 

--- a/fixSearchIndex.swift
+++ b/fixSearchIndex.swift
@@ -39,10 +39,14 @@ var searchIndexDocs = [SearchIndexDocs]()
 
 for doc in newSearchIndex.docs {
     if !doc.location.starts(with: "en/")
-      && !doc.location.starts(with: "zh/")
       && !doc.location.starts(with: "de/")
+      && !doc.location.starts(with: "es/")
       && !doc.location.starts(with: "fr/") 
-      && !doc.location.starts(with: "nl/") {
+      && !doc.location.starts(with: "it/") 
+      && !doc.location.starts(with: "ko/") 
+      && !doc.location.starts(with: "nl/") 
+      && !doc.location.starts(with: "pl/") 
+      && !doc.location.starts(with: "zk/") {
           searchIndexDocs.append(doc)
     }
 }


### PR DESCRIPTION
Adds the new translations to the search index script to ensure the new languages don't appear as currently everything is duplicated until all pages are fully translated or we can find better plugins that only search in the current language

Resolves #853 
