### PR TITLE
Fix version and name of the VaporAPNS package

### DIFF
--- a/docs/advanced/apns.md
+++ b/docs/advanced/apns.md
@@ -37,7 +37,7 @@ If you edit the manifest directly inside Xcode, it will automatically pick up th
 The APNS module adds a new property `apns` to `Application`. To send push notifications, you will need to set the `configuration` property with your credentials.
 
 ```swift
-import APNS
+import VaporAPNS
 
 // Configure APNS using JWT authentication.
 let apnsConfig = APNSClientConfiguration(

--- a/docs/advanced/apns.md
+++ b/docs/advanced/apns.md
@@ -18,12 +18,12 @@ let package = Package(
     name: "my-app",
     dependencies: [
          // Other dependencies...
-        .package(url: "https://github.com/vapor/apns.git", from: "5.0.0"),
+        .package(url: "https://github.com/vapor/apns.git", from: "4.0.0"),
     ],
     targets: [
         .target(name: "App", dependencies: [
             // Other dependencies...
-            .product(name: "APNS", package: "apns")
+            .product(name: "VaporAPNS", package: "apns")
         ]),
         // Other targets...
     ]


### PR DESCRIPTION
Version 5.0 of Vapor's APNS package does not appear to exist (https://github.com/vapor/apns/releases).