### PR TITLE
Update routing.md

### DIFF
--- a/docs/basics/routing.de.md
+++ b/docs/basics/routing.de.md
@@ -383,7 +383,7 @@ Für eine Weiterleitung kann es verschiedenste Gründe geben. Mit der Methode *r
 req.redirect(to: "/some/new/path")
 
 /// redirect a page permanently
-req.redirect(to: "/some/new/path", type: .permanent)
+req.redirect(to: "/some/new/path", redirectType: .permanent)
 ```
 
 Es gibt verschiedene Arten von Weiterleitungen:

--- a/docs/basics/routing.es.md
+++ b/docs/basics/routing.es.md
@@ -424,10 +424,10 @@ req.redirect(to: "/some/new/path")
 También puedes especificar el tipo de redirección, por ejemplo para redirigir una página de forma permanente (para que su SEO se actualice correctamente) usa:
 
 ```swift
-req.redirect(to: "/some/new/path", type: .permanent)
+req.redirect(to: "/some/new/path", redirectType: .permanent)
 ```
 
-Los diferentes `RedirectType` son:
+Los diferentes `Redirect` son:
 
 * `.permanent` - devuelve una redirección **301 Moved Permanently**
 * `.normal` - devuelve una redirección **303 See Other**. Este es el valor por defecto de Vapor y le dice al cliente que siga la redirección con una petición **GET**.

--- a/docs/basics/routing.md
+++ b/docs/basics/routing.md
@@ -427,7 +427,7 @@ You can also specify the type of redirect, for example to redirect a page perman
 req.redirect(to: "/some/new/path", redirectType: .permanent)
 ```
 
-The different `RedirectType`s are:
+The different `Redirect`s are:
 
 * `.permanent` - returns a **301 Permanent** redirect
 * `.normal` - returns a **303 see other** redirect. This is the default by Vapor and tells the client to follow the redirect with a **GET** request.

--- a/docs/basics/routing.md
+++ b/docs/basics/routing.md
@@ -424,7 +424,7 @@ req.redirect(to: "/some/new/path")
 You can also specify the type of redirect, for example to redirect a page permanently (so that your SEO is updated correctly) use:
 
 ```swift
-req.redirect(to: "/some/new/path", type: .permanent)
+req.redirect(to: "/some/new/path", redirectType: .permanent)
 ```
 
 The different `RedirectType`s are:

--- a/docs/basics/routing.nl.md
+++ b/docs/basics/routing.nl.md
@@ -423,7 +423,7 @@ req.redirect(to: "/some/new/path")
 U kunt ook het type omleiding specificeren, bijvoorbeeld om een pagina permanent om te leiden (zodat uw SEO correct wordt bijgewerkt) gebruiken we:
 
 ```swift
-req.redirect(to: "/some/new/path", type: .permanent)
+req.redirect(to: "/some/new/path", redirectType: .permanent)
 ```
 
 De verschillende `RedirectType`s zijn:

--- a/docs/basics/routing.nl.md
+++ b/docs/basics/routing.nl.md
@@ -426,7 +426,7 @@ U kunt ook het type omleiding specificeren, bijvoorbeeld om een pagina permanent
 req.redirect(to: "/some/new/path", redirectType: .permanent)
 ```
 
-De verschillende `RedirectType`s zijn:
+De verschillende `Redirect`s zijn:
 
 * `.permanent` - geeft een **301 Permanent** omleiding.
 * `.normal` - retourneert een **303 see other** redirect. Dit is de standaard door Vapor en vertelt de client om de omleiding te volgen met een **GET** verzoek.

--- a/docs/basics/routing.zh.md
+++ b/docs/basics/routing.zh.md
@@ -435,7 +435,7 @@ req.redirect(to: "/some/new/path")
 req.redirect(to: "/some/new/path", redirectType: .permanent)
 ```
 
-不同的 `RedirectType` 有：
+不同的 `Redirect` 有：
 
 * `.permanent` - 返回一个 **301 Permanent** 重定向。 
 * `.normal` - 返回一个 **303 see other** 重定向。这是 Vapor 的默认行为，来告诉客户端去使用一个 **GET** 请求来重定向。

--- a/docs/basics/routing.zh.md
+++ b/docs/basics/routing.zh.md
@@ -432,7 +432,7 @@ req.redirect(to: "/some/new/path")
 你可以设置重定向的类型，比如说永久的重定向一个页面（来使你的 SEO 正确的更新），请使用：
 
 ```swift
-req.redirect(to: "/some/new/path", type: .permanent)
+req.redirect(to: "/some/new/path", redirectType: .permanent)
 ```
 
 不同的 `RedirectType` 有：


### PR DESCRIPTION
Fixes typo on `Basics` docs section related to 'redirect(to:type:)' being deprecated and renamed to 'redirect(to:redirectType:)'

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
