### PR TITLE
Align apns versions and imports

### DIFF
--- a/docs/advanced/apns.it.md
+++ b/docs/advanced/apns.it.md
@@ -18,12 +18,12 @@ let package = Package(
     name: "my-app",
     dependencies: [
          // Altre dipendenze...
-        .package(url: "https://github.com/vapor/apns.git", from: "5.0.0"),
+        .package(url: "https://github.com/vapor/apns.git", from: "4.0.0"),
     ],
     targets: [
         .target(name: "App", dependencies: [
             // Altre dipendenze...
-            .product(name: "APNS", package: "apns")
+            .product(name: "VaporAPNS", package: "apns")
         ]),
         // Altri target...
     ]
@@ -38,6 +38,8 @@ Il modulo APNS aggiunge una nuova proprietà `apns` ad `Application`. Per inviar
 
 ```swift
 import APNS
+import VaporAPNS
+import APNSCore
 
 // Configurazione di APNS utilizzando l'autenticazione tramite JWT.
 let apnsConfig = APNSClientConfiguration(

--- a/docs/advanced/apns.md
+++ b/docs/advanced/apns.md
@@ -39,6 +39,7 @@ The APNS module adds a new property `apns` to `Application`. To send push notifi
 ```swift
 import APNS
 import VaporAPNS
+import APNSCore
 
 // Configure APNS using JWT authentication.
 let apnsConfig = APNSClientConfiguration(

--- a/docs/advanced/apns.nl.md
+++ b/docs/advanced/apns.nl.md
@@ -18,12 +18,12 @@ let package = Package(
     name: "my-app",
     dependencies: [
          // Andere afhankelijkheden...
-        .package(url: "https://github.com/vapor/apns.git", from: "3.0.0"),
+        .package(url: "https://github.com/vapor/apns.git", from: "4.0.0"),
     ],
     targets: [
         .target(name: "App", dependencies: [
             // Andere afhankelijkheden...
-            .product(name: "APNS", package: "apns")
+            .product(name: "VaporAPNS", package: "apns")
         ]),
         // Andere targets...
     ]
@@ -38,6 +38,8 @@ De APNS module voegt een nieuwe eigenschap `apns` toe aan `Application`. Om push
 
 ```swift
 import APNS
+import VaporAPNS
+import APNSCore
 
 // Configureer APNS met JWT-authenticatie.
 app.apns.configuration = try .init(

--- a/docs/advanced/apns.zh.md
+++ b/docs/advanced/apns.zh.md
@@ -18,12 +18,12 @@ let package = Package(
     name: "my-app",
     dependencies: [
          // Other dependencies...
-        .package(url: "https://github.com/vapor/apns.git", from: "5.0.0"),
+        .package(url: "https://github.com/vapor/apns.git", from: "4.0.0"),
     ],
     targets: [
         .target(name: "App", dependencies: [
             // Other dependencies...
-            .product(name: "APNS", package: "apns")
+            .product(name: "VaporAPNS", package: "apns")
         ]),
         // Other targets...
     ]
@@ -38,6 +38,8 @@ APNS 模块为 `Application` 添加了一个 `apns` 新属性。要发送推送�
 
 ```swift
 import APNS
+import VaporAPNS
+import APNSCore
 
 // 使用 JWT 认证 配置 APNS。
 let apnsConfig = APNSClientConfiguration(


### PR DESCRIPTION
Make sure that `import APNSCore` and `from: "4.0.0"` are present in all versions of `apns.md` in response to https://github.com/vapor/apns/issues/54.