### PR TITLE
Fix Typo in Fluent Overview

### DIFF
--- a/docs/fluent/overview.md
+++ b/docs/fluent/overview.md
@@ -365,7 +365,7 @@ app.post("galaxies") { req -> EventLoopFuture<Galaxy> in
 }
 ```
 
-!!! seealso
+!!! see also
     See [Content &rarr; Overview](../basics/content.md) for more information about decoding request bodies.
 
 Once you have an instance of the model, calling `create(on:)` saves the model to the database. This returns an `EventLoopFuture<Void>` which signals that the save has completed. Once the save completes, return the newly created model using `map`.


### PR DESCRIPTION
Fixed a Typo on the Fluent Overview Doc, replacing `seealso` with `see also`