### PR TITLE
Update documentation about ws.send(...) return value

### DIFF
--- a/docs/advanced/websockets.md
+++ b/docs/advanced/websockets.md
@@ -58,11 +58,10 @@ promise.futureResult.whenComplete { result in
 }
 ```
 
-If using `async`/`await` you can `await` on the result
+If using `async`/`await` you can use `await` to wait for the asynchronous operation to complete
 
 ```swift
-// TODO Check this actually works
-let result = try await ws.send(...)
+try await ws.send(...)
 ```
 
 ### Receiving


### PR DESCRIPTION
## Description

The current documentation incorrectly states that ws.send(...) returns a value which can be awaited. However, the WebSocket.send method does not have a return value.

## Reference

* [vapor/websocket-kit/Sources/WebSocketKit/Concurrency](https://github.com/vapor/websocket-kit/blob/main/Sources/WebSocketKit/Concurrency/WebSocket%2BConcurrency.swift)