### PR TITLE
fix typo & add missing 'with' argument label

### DIFF
--- a/docs/security/authentication.de.md
+++ b/docs/security/authentication.de.md
@@ -816,7 +816,7 @@ struct SessionToken: Content, Authenticatable, JWTPayload {
         self.expiration = ExpirationClaim(value: Date().addingTimeInterval(expirationTime))
     }
     
-    init(user: User) throws {
+    init(with user: User) throws {
         self.userId = try user.requireID()
         self.expiration = ExpirationClaim(value: Date().addingTimeInterval(expirationTime))
     }
@@ -830,30 +830,30 @@ struct SessionToken: Content, Authenticatable, JWTPayload {
 Als Nächstes können wir eine Darstellung der Daten definieren, die in einer erfolgreichen Anmeldeantwort enthalten sind. Zunächst wird die Antwort nur eine Eigenschaft haben, nämlich einen String, der ein signiertes JWT darstellt.
 
 ```swift
-struct ClientTokenReponse: Content {
+struct ClientTokenResponse: Content {
     var token: String
 }
 ```
 
-Mit unserem Modell für das JWT-Token und die Antwort können wir eine passwortgeschützte Login-Route verwenden, die eine "ClientTokenReponse" zurückgibt und ein signiertes "SessionToken" enthält.
+Mit unserem Modell für das JWT-Token und die Antwort können wir eine passwortgeschützte Login-Route verwenden, die eine "ClientTokenResponse" zurückgibt und ein signiertes "SessionToken" enthält.
 
 ```swift
 let passwordProtected = app.grouped(User.authenticator(), User.guardMiddleware())
-passwordProtected.post("login") { req -> ClientTokenReponse in
+passwordProtected.post("login") { req -> ClientTokenResponse in
     let user = try req.auth.require(User.self)
     let payload = try SessionToken(with: user)
-    return ClientTokenReponse(token: try req.jwt.sign(payload))
+    return ClientTokenResponse(token: try req.jwt.sign(payload))
 }
 ```
 
 Wenn du keinen Authentifikator verwenden willst, kannst du auch etwas haben, das wie folgt aussieht.
 
 ```swift
-app.post("login") { req -> ClientTokenReponse in
+app.post("login") { req -> ClientTokenResponse in
     // Überprüfe die angegebenen Anmeldeinformationen für den Benutzer
     // UserId für den angegebenen Benutzer abrufen
     let payload = try SessionToken(userId: userId)
-    return ClientTokenReponse(token: try req.jwt.sign(payload))
+    return ClientTokenResponse(token: try req.jwt.sign(payload))
 }
 ```
 

--- a/docs/security/authentication.it.md
+++ b/docs/security/authentication.it.md
@@ -834,7 +834,7 @@ struct SessionToken: Content, Authenticatable, JWTPayload {
         self.expiration = ExpirationClaim(value: Date().addingTimeInterval(expirationTime))
     }
     
-    init(user: User) throws {
+    init(with user: User) throws {
         self.userId = try user.requireID()
         self.expiration = ExpirationClaim(value: Date().addingTimeInterval(expirationTime))
     }
@@ -848,30 +848,30 @@ struct SessionToken: Content, Authenticatable, JWTPayload {
 Successivamente, possiamo definire una rappresentazione dei dati contenuti in una risposta di login andata a buon fine. Per ora la risposta avrà solo una proprietà, una stringa che rappresenta un JWT firmato.
 
 ```swift
-struct ClientTokenReponse: Content {
+struct ClientTokenResponse: Content {
     var token: String
 }
 ```
 
-Utilizzando il nostro modello per il token JWT e la risposta, possiamo usare una route di login protetta da password che restituisce un `ClientTokenReponse` e include un `SessionToken` firmato.
+Utilizzando il nostro modello per il token JWT e la risposta, possiamo usare una route di login protetta da password che restituisce un `ClientTokenResponse` e include un `SessionToken` firmato.
 
 ```swift
 let passwordProtected = app.grouped(User.authenticator(), User.guardMiddleware())
-passwordProtected.post("login") { req -> ClientTokenReponse in
+passwordProtected.post("login") { req -> ClientTokenResponse in
     let user = try req.auth.require(User.self)
     let payload = try SessionToken(with: user)
-    return ClientTokenReponse(token: try req.jwt.sign(payload))
+    return ClientTokenResponse(token: try req.jwt.sign(payload))
 }
 ```
 
 In alternativa, se non vuoi usare un autenticatore, puoi avere qualcosa di simile a questo:
 
 ```swift
-app.post("login") { req -> ClientTokenReponse in
+app.post("login") { req -> ClientTokenResponse in
     // Valida le credenziali dell'utente
     // Ottieni lo userId dell'utente
     let payload = try SessionToken(userId: userId)
-    return ClientTokenReponse(token: try req.jwt.sign(payload))
+    return ClientTokenResponse(token: try req.jwt.sign(payload))
 }
 ```
 

--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -836,7 +836,7 @@ struct SessionToken: Content, Authenticatable, JWTPayload {
         self.expiration = ExpirationClaim(value: Date().addingTimeInterval(expirationTime))
     }
     
-    init(user: User) throws {
+    init(with user: User) throws {
         self.userId = try user.requireID()
         self.expiration = ExpirationClaim(value: Date().addingTimeInterval(expirationTime))
     }
@@ -850,29 +850,29 @@ struct SessionToken: Content, Authenticatable, JWTPayload {
 Next, we can define a representation of the data contained in a successful login response. For now the response will only have one property which is a string representing a signed JWT.
 
 ```swift
-struct ClientTokenReponse: Content {
+struct ClientTokenResponse: Content {
     var token: String
 }
 ```
 
-Using our model for the JWT token and response, we can use a password protected login route which returns a `ClientTokenReponse` and includes a signed `SessionToken`.
+Using our model for the JWT token and response, we can use a password protected login route which returns a `ClientTokenResponse` and includes a signed `SessionToken`.
 
 ```swift
 let passwordProtected = app.grouped(User.authenticator(), User.guardMiddleware())
-passwordProtected.post("login") { req async throws -> ClientTokenReponse in
+passwordProtected.post("login") { req async throws -> ClientTokenResponse in
     let user = try req.auth.require(User.self)
     let payload = try SessionToken(with: user)
-    return ClientTokenReponse(token: try await req.jwt.sign(payload))
+    return ClientTokenResponse(token: try await req.jwt.sign(payload))
 }
 ```
 
 Alternatively, if you don't want to use an authenticator you can have something that looks like the following.
 ```swift
-app.post("login") { req async throws -> ClientTokenReponse in
+app.post("login") { req async throws -> ClientTokenResponse in
     // Validate provided credential for user
     // Get userId for provided user
     let payload = try SessionToken(userId: userId)
-    return ClientTokenReponse(token: try await req.jwt.sign(payload))
+    return ClientTokenResponse(token: try await req.jwt.sign(payload))
 }
 ```
 

--- a/docs/security/authentication.nl.md
+++ b/docs/security/authentication.nl.md
@@ -833,7 +833,7 @@ struct SessionToken: Content, Authenticatable, JWTPayload {
         self.expiration = ExpirationClaim(value: Date().addingTimeInterval(expirationTime))
     }
     
-    init(user: User) throws {
+    init(with user: User) throws {
         self.userId = try user.requireID()
         self.expiration = ExpirationClaim(value: Date().addingTimeInterval(expirationTime))
     }
@@ -847,29 +847,29 @@ struct SessionToken: Content, Authenticatable, JWTPayload {
 Vervolgens kunnen we een representatie definiëren van de gegevens in een succesvol login antwoord. Voorlopig zal het antwoord slechts één eigenschap hebben, namelijk een string die een ondertekende JWT voorstelt.
 
 ```swift
-struct ClientTokenReponse: Content {
+struct ClientTokenResponse: Content {
     var token: String
 }
 ```
 
-Met behulp van ons model voor de JWT token en respons, kunnen we een wachtwoord beveiligde login route gebruiken die een `ClientTokenReponse` retourneert en een ondertekende `SessionToken` bevat.
+Met behulp van ons model voor de JWT token en respons, kunnen we een wachtwoord beveiligde login route gebruiken die een `ClientTokenResponse` retourneert en een ondertekende `SessionToken` bevat.
 
 ```swift
 let passwordProtected = app.grouped(User.authenticator(), User.guardMiddleware())
-passwordProtected.post("login") { req -> ClientTokenReponse in
+passwordProtected.post("login") { req -> ClientTokenResponse in
     let user = try req.auth.require(User.self)
     let payload = try SessionToken(with: user)
-    return ClientTokenReponse(token: try req.jwt.sign(payload))
+    return ClientTokenResponse(token: try req.jwt.sign(payload))
 }
 ```
 
 Als alternatief, als u geen authenticator wilt gebruiken, kunt u iets hebben dat er als volgt uitziet.
 ```swift
-app.post("login") { req -> ClientTokenReponse in
+app.post("login") { req -> ClientTokenResponse in
     // Valideer verstrekte inloggegevens voor gebruiker
     // Verkrijg gebruikersId voor opgegeven gebruiker
     let payload = try SessionToken(userId: userId)
-    return ClientTokenReponse(token: try req.jwt.sign(payload))
+    return ClientTokenResponse(token: try req.jwt.sign(payload))
 }
 ```
 

--- a/docs/security/authentication.zh.md
+++ b/docs/security/authentication.zh.md
@@ -834,7 +834,7 @@ struct SessionToken: Content, Authenticatable, JWTPayload {
         self.expiration = ExpirationClaim(value: Date().addingTimeInterval(expirationTime))
     }
     
-    init(user: User) throws {
+    init(with user: User) throws {
         self.userId = try user.requireID()
         self.expiration = ExpirationClaim(value: Date().addingTimeInterval(expirationTime))
     }
@@ -848,30 +848,30 @@ struct SessionToken: Content, Authenticatable, JWTPayload {
 接下来，我们可以定义成功登录响应中包含的数据的表示形式。目前，响应将只有一个属性，即表示已签名的 JWT 的字符串。
 
 ```swift
-struct ClientTokenReponse: Content {
+struct ClientTokenResponse: Content {
     var token: String
 }
 ```
 
-使用我们的 JWT 令牌和响应模型，我们可以使用受密码保护的登录路由，该路由返回一个 `ClientTokenReponse` 并包含一个已签名的 `SessionToken`。
+使用我们的 JWT 令牌和响应模型，我们可以使用受密码保护的登录路由，该路由返回一个 `ClientTokenResponse` 并包含一个已签名的 `SessionToken`。
 
 ```swift
 let passwordProtected = app.grouped(User.authenticator(), User.guardMiddleware())
-passwordProtected.post("login") { req -> ClientTokenReponse in
+passwordProtected.post("login") { req -> ClientTokenResponse in
     let user = try req.auth.require(User.self)
     let payload = try SessionToken(with: user)
-    return ClientTokenReponse(token: try req.jwt.sign(payload))
+    return ClientTokenResponse(token: try req.jwt.sign(payload))
 }
 ```
 
 或者，如果你不想使用身份认证器，则可以使用如下所示的内容。
 
 ```swift
-app.post("login") { req -> ClientTokenReponse in
+app.post("login") { req -> ClientTokenResponse in
     // 验证为用户提供的凭据
     // 获取提供的用户的 userId
     let payload = try SessionToken(userId: userId)
-    return ClientTokenReponse(token: try req.jwt.sign(payload))
+    return ClientTokenResponse(token: try req.jwt.sign(payload))
 }
 ```
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->
fix typo `ClientTokenReponse` => `ClientTokenResponse` (réponse to response)
<!-- Describe your changes clearly and use examples if possible. -->


add missing `with` argument label in the initializer of `SessionToken` to fix "Incorrect argument label in call (have 'with:', expected 'user:')".
<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
