### PR TITLE
Fix Error Middleware docs

### DIFF
--- a/docs/basics/errors.md
+++ b/docs/basics/errors.md
@@ -183,13 +183,14 @@ StackTrace.isCaptureEnabled = true
 
 ## Error Middleware
 
-`ErrorMiddleware` is the only middleware added to your application by default. This middleware converts Swift errors that have been thrown or returned by your route handlers into HTTP responses. Without this middleware, errors thrown will result in the connection being closed without a response. 
+`ErrorMiddleware` is one of the only two middlewares added to your application by default. This middleware converts Swift errors that have been thrown or returned by your route handlers into HTTP responses. Without this middleware, errors thrown will result in the connection being closed without a response. 
 
-To customize error handling beyond what `AbortError` and `DebuggableError` provide, you can replace `ErrorMiddleware` with your own error handling logic. To do this, first remove the default error middleware by setting `app.middleware` to an empty configuration. Then, add your own error handling middleware as the first middleware to your application.
+To customize error handling beyond what `AbortError` and `DebuggableError` provide, you can replace `ErrorMiddleware` with your own error handling logic. To do this, first remove the default error middleware by manually initializing `app.middleware`. Then, add your own error handling middleware as the first middleware to your application.
 
 ```swift
-// Remove all existing middleware.
+// Clear all default middleware (then, add back route logging)
 app.middleware = .init()
+app.middleware.use(RouteLoggingMiddleware(logLevel: .info))
 // Add custom error handling middleware first.
 app.middleware.use(MyErrorMiddleware())
 ```


### PR DESCRIPTION
[`ErrorMiddleware` is not the only middleware added by default](https://github.com/vapor/vapor/blob/cc98361cbec22757a89a9717836293f215a0f67d/Sources/Vapor/Middleware/Application%2BMiddleware.swift#L8). This PR updates that assertion and the replacement instructions to re-introduce `RouteLoggingMiddleware`.