### PR TITLE
fixed missing s as per Python string expression syntax

### DIFF
--- a/docs/deploy/supervisor.md
+++ b/docs/deploy/supervisor.md
@@ -34,8 +34,8 @@ Each Vapor app on your server should have its own configuration file. For an exa
 command=/home/vapor/hello/.build/release/App serve --env production
 directory=/home/vapor/hello/
 user=vapor
-stdout_logfile=/var/log/supervisor/%(program_name)-stdout.log
-stderr_logfile=/var/log/supervisor/%(program_name)-stderr.log
+stdout_logfile=/var/log/supervisor/%(program_name)s-stdout.log
+stderr_logfile=/var/log/supervisor/%(program_name)s-stderr.log
 ```
 
 As specified in our configuration file the `Hello` project is located in the home folder for the user `vapor`. Make sure `directory` points to the root directory of your project where the `Package.swift` file is.

--- a/docs/deploy/supervisor.nl.md
+++ b/docs/deploy/supervisor.nl.md
@@ -34,8 +34,8 @@ Elke Vapor toepassing op uw server zou zijn eigen configuratiebestand moeten heb
 command=/home/vapor/hello/.build/release/App serve --env production
 directory=/home/vapor/hello/
 user=vapor
-stdout_logfile=/var/log/supervisor/%(program_name)-stdout.log
-stderr_logfile=/var/log/supervisor/%(program_name)-stderr.log
+stdout_logfile=/var/log/supervisor/%(program_name)s-stdout.log
+stderr_logfile=/var/log/supervisor/%(program_name)s-stderr.log
 ```
 
 Zoals gespecificeerd in ons configuratie bestand staat het `Hello` project in de thuismap van de gebruiker `vapor`. Zorg ervoor dat `directory` wijst naar de root directory van uw project waar het `Package.swift` bestand staat.

--- a/docs/deploy/supervisor.zh.md
+++ b/docs/deploy/supervisor.zh.md
@@ -34,8 +34,8 @@ sudo dnf install supervisor
 command=/home/vapor/hello/.build/release/App serve --env production
 directory=/home/vapor/hello/
 user=vapor
-stdout_logfile=/var/log/supervisor/%(program_name)-stdout.log
-stderr_logfile=/var/log/supervisor/%(program_name)-stderr.log
+stdout_logfile=/var/log/supervisor/%(program_name)s-stdout.log
+stderr_logfile=/var/log/supervisor/%(program_name)s-stderr.log
 ```
 
 正如我们的配置文件中所指定的， `Hello` 项目位于用户 `vapor` 的主文件夹中。确保 `directory` 指向 `Package.swift` 文件所在项目的根目录。


### PR DESCRIPTION
supervisord uses the Python string expression syntax in its configuration files, like this `%(ENV_X)s `
It's described here: http://supervisord.org/configuration.html#environment-variables
In the "Deploy->Supervisor->Configure"  section of the documentation the final "s" were omitted: 
https://docs.vapor.codes/deploy/supervisor/#configure
so copy-pasting this example was leading to wrong file names of the logs.
For example, instead of the expected file name `hello-stdout.log` I had the wrong `hellotdout.log`.