### PR TITLE
Update TLS example in Docs

### DIFF
--- a/docs/advanced/server.md
+++ b/docs/advanced/server.md
@@ -141,7 +141,7 @@ The `tlsConfiguration` parameter controls whether TLS (SSL) is enabled on the se
 // Enable TLS.
 app.http.server.configuration.tlsConfiguration = .makeServerConfiguration(
     certificateChain: try NIOSSLCertificate.fromPEMFile("/path/to/cert.pem").map { .certificate($0) },
-    privateKey: .file("/path/to/key.pem")
+    privateKey: try NIOSSLPrivateKey(file: "/path/to/key.pem", format: .pem))
 )
 ```
 


### PR DESCRIPTION
The enable TLS example didn't work for me locally. I eventually figured out that `NIOSSLPrivateKeySource` was required.