### PR TITLE
Update link to QueuesFluentDriver

### DIFF
--- a/docs/advanced/queues.md
+++ b/docs/advanced/queues.md
@@ -26,7 +26,7 @@ Queues currently has one officially supported driver which interfaces with the m
 Queues also has community-based drivers:
 
 - [QueuesMongoDriver](https://github.com/vapor-community/queues-mongo-driver)
-- [QueuesFluentDriver](https://github.com/m-barthelemy/vapor-queues-fluent-driver)
+- [QueuesFluentDriver](https://github.com/vapor-community/vapor-queues-fluent-driver)
 
 !!! tip
     You should not install the `vapor/queues` package directly unless you are building a new driver. Install one of the driver packages instead. 


### PR DESCRIPTION
In the docs section for Vapor Queues, update the link to `QueuesFluentDriver` to link to the most recent iteration forked and hosted under the `vapor-community` organization.
