### PR TITLE
Fixed syntax error on TLS section on Advanced -> Server

### DIFF
--- a/docs/advanced/server.de.md
+++ b/docs/advanced/server.de.md
@@ -132,7 +132,7 @@ Der Parameter _tlsConfiguration_ legt fest, ob TLS (SSL) verwendet werden soll. 
 // Enable TLS.
 app.http.server.configuration.tlsConfiguration = .makeServerConfiguration(
     certificateChain: try NIOSSLCertificate.fromPEMFile("/path/to/cert.pem").map { .certificate($0) },
-    privateKey: try NIOSSLPrivateKey(file: "/path/to/key.pem", format: .pem))
+    privateKey: .privateKey(try NIOSSLPrivateKey(file: "/path/to/key.pem", format: .pem))
 )
 ```
 

--- a/docs/advanced/server.es.md
+++ b/docs/advanced/server.es.md
@@ -140,7 +140,7 @@ El parámetro `tlsConfiguration` controla si TLS (SSL) está habilitado en el se
 // Habilitar TLS.
 app.http.server.configuration.tlsConfiguration = .makeServerConfiguration(
     certificateChain: try NIOSSLCertificate.fromPEMFile("/path/to/cert.pem").map { .certificate($0) },
-    privateKey: try NIOSSLPrivateKey(file: "/path/to/key.pem", format: .pem))
+    privateKey: .privateKey(try NIOSSLPrivateKey(file: "/path/to/key.pem", format: .pem))
 )
 ```
 

--- a/docs/advanced/server.md
+++ b/docs/advanced/server.md
@@ -141,7 +141,7 @@ The `tlsConfiguration` parameter controls whether TLS (SSL) is enabled on the se
 // Enable TLS.
 app.http.server.configuration.tlsConfiguration = .makeServerConfiguration(
     certificateChain: try NIOSSLCertificate.fromPEMFile("/path/to/cert.pem").map { .certificate($0) },
-    privateKey: try NIOSSLPrivateKey(file: "/path/to/key.pem", format: .pem))
+    privateKey: .privateKey(try NIOSSLPrivateKey(file: "/path/to/key.pem", format: .pem))
 )
 ```
 

--- a/docs/advanced/server.nl.md
+++ b/docs/advanced/server.nl.md
@@ -141,7 +141,7 @@ De `tlsConfiguration` parameter regelt of TLS (SSL) is ingeschakeld op de server
 // Schakel TLS in.
 app.http.server.configuration.tlsConfiguration = .makeServerConfiguration(
     certificateChain: try NIOSSLCertificate.fromPEMFile("/path/to/cert.pem").map { .certificate($0) },
-    privateKey: try NIOSSLPrivateKey(file: "/path/to/key.pem", format: .pem))
+    privateKey: .privateKey(try NIOSSLPrivateKey(file: "/path/to/key.pem", format: .pem))
 )
 ```
 

--- a/docs/advanced/server.zh.md
+++ b/docs/advanced/server.zh.md
@@ -140,7 +140,7 @@ app.http.server.configuration.supportVersions = [.two]
 // 启用 TLS.
 app.http.server.configuration.tlsConfiguration = .makeServerConfiguration(
     certificateChain: try NIOSSLCertificate.fromPEMFile("/path/to/cert.pem").map { .certificate($0) },
-    privateKey: try NIOSSLPrivateKey(file: "/path/to/key.pem", format: .pem))
+    privateKey: .privateKey(try NIOSSLPrivateKey(file: "/path/to/key.pem", format: .pem))
 )
 ```
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

There was a syntax error in the TLS Section:

Before:
```swift
// Enable TLS.
app.http.server.configuration.tlsConfiguration = .makeServerConfiguration(
    certificateChain: try NIOSSLCertificate.fromPEMFile("/path/to/cert.pem").map { .certificate($0) },
    privateKey: try NIOSSLPrivateKey(file: "/path/to/key.pem", format: .pem))
)
```

Error:
<img width="1079" alt="Screenshot 2025-02-25 at 13 35 30" src="https://github.com/user-attachments/assets/2bac6d83-18eb-4968-9306-0e874a22db7b" />

After:
```swift
app.http.server.configuration.tlsConfiguration = .makeServerConfiguration(
        certificateChain: try NIOSSLCertificate.fromPEMFile("/path/to/cert.pem").map { .certificate($0) },
        privateKey: .privateKey(try NIOSSLPrivateKey(file: "/path/to/key.pem", format: .pem))
    )
```
<img width="1047" alt="Screenshot 2025-02-25 at 13 36 04" src="https://github.com/user-attachments/assets/b30f3b63-ff7f-4c2e-8278-2997404feb0b" />

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
