### PR TITLE
Adding a "in" keyword in JTW's post route example.

### DIFF
--- a/docs/security/jwt.md
+++ b/docs/security/jwt.md
@@ -93,7 +93,7 @@ struct TestPayload: JWTPayload {
 Signing the payload is done by calling the `sign` method on the `JWT` module, for example inside of a route handler:
 
 ```swift
-app.post("login") { req async throws -> [String: String]
+app.post("login") { req async throws -> [String: String] in
     let payload = TestPayload(
         subject: "vapor",
         expiration: .init(value: .distantFuture),


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->
There was a "in" keyword missing in the post route example for signing JWTs. The keyword was simply added to the code snippet.
<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
