### PR TITLE
Reordered languages & added original names in translation_needed

### DIFF
--- a/.github/translation_needed.description.leaf
+++ b/.github/translation_needed.description.leaf
@@ -2,14 +2,15 @@ The docs have been updated in PR ##(number). The translations should be updated 
 
 Languages:
 - [ ] English
-- [ ] Chinese
-- [ ] German
-- [ ] Dutch
-- [ ] Italian
-- [ ] Spanish
-- [ ] Polish
-- [ ] Korean
-- [ ] Japanese
+- [ ] Deutsch (German)
+- [ ] Español (Spanish)
+- [ ] Français (French)
+- [ ] Italiano (Italian)
+- [ ] 日本語 (Japanese)
+- [ ] 한국어 (Korean)
+- [ ] Nederlands (Dutch)
+- [ ] Polski (Polish)
+- [ ] 简体中文 (Simplified Chinese)
 
 Assigned to @vapor/translators - please submit a PR with the relevant updates and check the box once merged.
 Please ensure you tag your PR with the `translation-update` so it doesn't create a new issue!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,147 +96,8 @@ plugins:
           name: English
         - build: true
           default: false
-          locale: zh
-          name: 简体中文
-          nav_translations:
-            APNS: 苹果推送服务
-            Advanced: 进阶
-            Async: 异步
-            Authentication: 认证
-            Basics: 入门
-            Client: 客户端
-            Commands: 命令
-            Content: 内容
-            Contributing: 贡献
-            Contributing Guide: 贡献指南
-            Crypto: 加密
-            Custom Tags: 自定义标签
-            Deploy: 部署
-            Environment: 环境
-            Errors: 错误
-            Files: 文件
-            Fluent: Fluent
-            Folder Structure: 项目结构
-            Getting Started: 开始
-            Hello, world: 你好世界
-            Install: 安装
-            JWT: JWT
-            Leaf: Leaf
-            Logging: 日志
-            Middleware: 中间件
-            Migrations: 迁移
-            Model: 模型
-            Overview: 概述
-            Passwords: 密码
-            Query: 查询
-            Queues: 队列
-            Redis: Redis
-            Relations: 关联
-            Routing: 路由
-            Schema: 模式
-            Security: 安全
-            Server: 服务器
-            Services: 服务
-            Sessions: 会话
-            SwiftPM: Swift 包管理器
-            Testing: 测试
-            Transactions: 事务
-            Validation: 验证
-            Version (4.0): 版本 (4.0)
-            WebSockets: 即时通讯
-            Welcome: 序言
-            Xcode: Xcode
-          site_name: Vapor 中文文档
-        - build: true
-          default: false
-          locale: nl
-          name: Nederlands
-          nav_translations:
-            Advanced: Geavanceerd
-            Async: Asynchroon
-            Authentication: Authenticatie
-            Basics: Basis
-            Commands: Commando's
-            Content: Inhoud
-            Contributing: Bijdragen
-            Contributing Guide: Gids Bijdragen
-            Crypto: Encryptie
-            Custom Tags: Zelfgemaakte Tags
-            Deploy: Opzetten
-            Environment: Omgeving
-            Files: Bestanden
-            Folder Structure: Folder Structuur
-            Getting Started: Aan De Slag
-            Hello, world: Hallo, wereld
-            Install: Installeren
-            Legacy Docs: Oude Documentatie
-            Logging: Loggen
-            Migrations: Migraties
-            Overview: Overzicht
-            Passwords: Wachtwoorden
-            Query: Opvragen
-            Queues: Wachtrijen
-            Relations: Relaties
-            Routing: Routering
-            Schema: Schema
-            Security: Veiligheid
-            Services: Diensten
-            Sessions: Sessies
-            Testing: Testen
-            Transactions: Transacties
-            Upgrading: Upgraden
-            Validation: Validatie
-            Version (4.0): Versie (4.0)
-            Welcome: Welkom
-          site_name: Vapor Documentatie
-        - build: true
-          default: false
-          locale: fr
-          name: Français
-          nav_translations:
-            Advanced: Avancé
-            Async: Asynchrone
-            Authentication: Authentification
-            Basics: Bases
-            Commands: Commandes
-            Content: Contenu
-            Contributing: Contribuer
-            Contributing Guide: Guide de contribution
-            Controllers: Contrôleurs
-            Custom Tags: Tags customisés
-            Errors: Erreurs
-            Deploy: Deployer
-            Environment: Environement
-            Files: Fichiers
-            Folder Structure: Structure du Dossier
-            Getting Started: Commencer
-            Hello, world: Bonjour, monde
-            Install: Installer
-            Legacy Docs: Documents hérité
-            Migrations: Migrations
-            Overview: Aperçu
-            Passwords: Mots de passe
-            Query: Requête
-            Queues: Files d'attente
-            Relataions: Relations
-            Release Notes: Notes de Version
-            Request: Requête
-            Routing: Routage
-            Schema: Schema
-            Security: Securité
-            Services: Services
-            Sessions: Sessions
-            Testing: Test
-            Transactions: Transactions
-            Upgrading: Mettre à jour
-            Validation: Validation
-            Version (4.0): Version (4.0)
-            Welcome: Bienvenue
-          site_name: Documentation Vapor
-        - build: true
-          default: false
           locale: de
-          name: German
+          name: Deutsch
           nav_translations:
             Advanced: Erweitert
             Authentication: Authentifzierung
@@ -267,63 +128,6 @@ plugins:
             Validation: Validierung
             Welcome: Begrüßung
           site_name: Vapor Dokumentation
-        - build: true
-          default: false
-          locale: it
-          name: Italiano
-          nav_translations:
-            APNS: APNS
-            Advanced: Avanzate
-            Async: Asincrono
-            Authentication: Autenticazione
-            Basics: Basi
-            Client: Client
-            Commands: Comandi
-            Content: Contenuto
-            Contributing: Contribuire
-            Contributing Guide: Guida alla Contribuzione
-            Controllers: Controller
-            Crypto: Crittografia
-            Custom Tags: Tag Personalizzati
-            Deploy: Deploy
-            Environment: Ambiente
-            Errors: Errori
-            Files: File
-            Fluent: Fluent
-            Folder Structure: Struttura della Cartella
-            Getting Started: Inizio
-            Hello, world: Ciao, mondo
-            Install: Installazione
-            JWT: JWT
-            Leaf: Leaf
-            Legacy Docs: Documentazione Obsoleta
-            Logging: Logging
-            Middleware: Middleware
-            Migrations: Migrazioni
-            Model: Modello
-            Overview: Panoramica
-            Passwords: Password
-            Query: Query
-            Queues: Code
-            Redis: Redis
-            Relations: Relazioni
-            Release Notes: Note sulla Versione
-            Routing: Routing
-            Schema: Schema
-            Security: Sicurezza
-            Server: Server
-            Services: Servizi
-            Sessions: Sessioni
-            SwiftPM: SwiftPM
-            Testing: Test
-            Transactions: Transazioni
-            Upgrading: Aggiornamento
-            Validation: Validazione
-            Version (4.0): Versione (4.0)
-            WebSockets: WebSockets
-            Welcome: Benvenuto
-            Xcode: Xcode
-          site_name: Documentazione di Vapor
         - build: true
           default: false
           locale: es
@@ -384,6 +188,239 @@ plugins:
           site_name: Documentación de Vapor
         - build: true
           default: false
+          locale: fr
+          name: Français
+          nav_translations:
+            Advanced: Avancé
+            Async: Asynchrone
+            Authentication: Authentification
+            Basics: Bases
+            Commands: Commandes
+            Content: Contenu
+            Contributing: Contribuer
+            Contributing Guide: Guide de contribution
+            Controllers: Contrôleurs
+            Custom Tags: Tags customisés
+            Errors: Erreurs
+            Deploy: Deployer
+            Environment: Environement
+            Files: Fichiers
+            Folder Structure: Structure du Dossier
+            Getting Started: Commencer
+            Hello, world: Bonjour, monde
+            Install: Installer
+            Legacy Docs: Documents hérité
+            Migrations: Migrations
+            Overview: Aperçu
+            Passwords: Mots de passe
+            Query: Requête
+            Queues: Files d'attente
+            Relataions: Relations
+            Release Notes: Notes de Version
+            Request: Requête
+            Routing: Routage
+            Schema: Schema
+            Security: Securité
+            Services: Services
+            Sessions: Sessions
+            Testing: Test
+            Transactions: Transactions
+            Upgrading: Mettre à jour
+            Validation: Validation
+            Version (4.0): Version (4.0)
+            Welcome: Bienvenue
+          site_name: Documentation de Vapor
+        - build: true
+          default: false
+          locale: it
+          name: Italiano
+          nav_translations:
+            APNS: APNS
+            Advanced: Avanzate
+            Async: Asincrono
+            Authentication: Autenticazione
+            Basics: Basi
+            Client: Client
+            Commands: Comandi
+            Content: Contenuto
+            Contributing: Contribuire
+            Contributing Guide: Guida alla Contribuzione
+            Controllers: Controller
+            Crypto: Crittografia
+            Custom Tags: Tag Personalizzati
+            Deploy: Deploy
+            Environment: Ambiente
+            Errors: Errori
+            Files: File
+            Fluent: Fluent
+            Folder Structure: Struttura della Cartella
+            Getting Started: Inizio
+            Hello, world: Ciao, mondo
+            Install: Installazione
+            JWT: JWT
+            Leaf: Leaf
+            Legacy Docs: Documentazione Obsoleta
+            Logging: Logging
+            Middleware: Middleware
+            Migrations: Migrazioni
+            Model: Modello
+            Overview: Panoramica
+            Passwords: Password
+            Query: Query
+            Queues: Code
+            Redis: Redis
+            Relations: Relazioni
+            Release Notes: Note sulla Versione
+            Routing: Routing
+            Schema: Schema
+            Security: Sicurezza
+            Server: Server
+            Services: Servizi
+            Sessions: Sessioni
+            SwiftPM: SwiftPM
+            Testing: Test
+            Transactions: Transazioni
+            Upgrading: Aggiornamento
+            Validation: Validazione
+            Version (4.0): Versione (4.0)
+            WebSockets: WebSockets
+            Welcome: Benvenuto
+            Xcode: Xcode
+          site_name: Documentazione di Vapor
+        - build: true
+          default: false
+          locale: ja
+          name: 日本語
+          nav_translations:
+            Advanced: 上級
+            Async: 非同期
+            Authentication: 認証
+            Basics: 基礎
+            Client: クライアント
+            Commands: コマンド
+            Content: コンテンツ
+            Contributing: 貢献
+            Contributing Guide: 貢献ガイド
+            Controllers: コントローラー
+            Crypto: 暗号
+            Custom Tags: カスタムタグ
+            Deploy: デプロイ
+            Environment: 環境
+            Errors: エラー
+            Files: ファイル
+            Folder Structure: フォルダ構造
+            Getting Started: はじめに
+            Install: インストール
+            Legacy Docs: レガシードキュメント
+            Logging: ロギング
+            Migrations: マイグレーション
+            Model: モデル
+            Overview: 概要
+            Passwords: パスワード
+            Query: クエリ
+            Queues: キュー
+            Relations: 関係
+            Release Notes: リリースノート
+            Routing: ルーティング
+            Schema: スキーマ
+            Security: セキュリティ
+            Services: サービス
+            Sessions: セッション
+            Testing: テスト
+            Transactions: トランザクション
+            Upgrading: アップグレード
+            Validation: バリデーション
+            Welcome: ようこそ
+          site_name: Vapor ドキュメント
+        - build: true
+          default: false
+          locale: ko
+          name: 한국어
+          nav_translations:
+            Advanced: 고급
+            Async: 비동기 처리
+            Authentication: 인증
+            Basics: 기본 사항
+            Client: 클라이언트
+            Commands: 명령어
+            Content: 컨텐츠
+            Contributing: 기여하기
+            Contributing Guide: 기여 가이드
+            Crypto: 암호화
+            Custom Tags: 사용자 정의 태그
+            Deploy: 배포
+            Environment: 환경 설정
+            Errors: 에러
+            Files: 파일
+            Folder Structure: 폴더 구조
+            Getting Started: 시작하기
+            Install: 설치
+            Legacy Docs: 이전 문서
+            Logging: 로깅
+            Migrations: 마이그레이션
+            Model: 모델
+            Overview: 개요
+            Passwords: 비밀번호
+            Query: 쿼리
+            Queues: 대기열
+            Relations: 관계
+            Routing: 라우팅
+            Schema: 스키마
+            Security: 보안
+            Services: 서비스
+            Sessions: 세션
+            Testing: 테스트
+            Transactions: 트랜잭션
+            Upgrading: 업그레이드
+            Validation: 유효성 검사
+            Version (4.0): 버전 (4.0)
+            WebSockets: 웹소켓
+            Welcome: 환영합니다
+          site_name: Vapor 문서
+        - build: true
+          default: false
+          locale: nl
+          name: Nederlands
+          nav_translations:
+            Advanced: Geavanceerd
+            Async: Asynchroon
+            Authentication: Authenticatie
+            Basics: Basis
+            Commands: Commando's
+            Content: Inhoud
+            Contributing: Bijdragen
+            Contributing Guide: Gids Bijdragen
+            Crypto: Encryptie
+            Custom Tags: Zelfgemaakte Tags
+            Deploy: Opzetten
+            Environment: Omgeving
+            Files: Bestanden
+            Folder Structure: Folder Structuur
+            Getting Started: Aan De Slag
+            Hello, world: Hallo, wereld
+            Install: Installeren
+            Legacy Docs: Oude Documentatie
+            Logging: Loggen
+            Migrations: Migraties
+            Overview: Overzicht
+            Passwords: Wachtwoorden
+            Query: Opvragen
+            Queues: Wachtrijen
+            Relations: Relaties
+            Routing: Routering
+            Schema: Schema
+            Security: Veiligheid
+            Services: Diensten
+            Sessions: Sessies
+            Testing: Testen
+            Transactions: Transacties
+            Upgrading: Upgraden
+            Validation: Validatie
+            Version (4.0): Versie (4.0)
+            Welcome: Welkom
+          site_name: Vapor Documentatie
+        - build: true
+          default: false
           locale: pl
           name: Polski
           nav_translations:
@@ -440,94 +477,57 @@ plugins:
           site_name: Dokumentacja Vapor
         - build: true
           default: false
-          locale: ko
-          name: 한국어
+          locale: zh
+          name: 简体中文
           nav_translations:
-            Advanced: 고급
-            Async: 비동기 처리
-            Authentication: 인증
-            Basics: 기본 사항
-            Client: 클라이언트
-            Commands: 명령어
-            Content: 컨텐츠
-            Contributing: 기여하기
-            Contributing Guide: 기여 가이드
-            Crypto: 암호화
-            Custom Tags: 사용자 정의 태그
-            Deploy: 배포
-            Environment: 환경 설정
-            Errors: 에러
-            Files: 파일
-            Folder Structure: 폴더 구조
-            Getting Started: 시작하기
-            Install: 설치
-            Legacy Docs: 이전 문서
-            Logging: 로깅
-            Migrations: 마이그레이션
-            Model: 모델
-            Overview: 개요
-            Passwords: 비밀번호
-            Query: 쿼리
-            Queues: 대기열
-            Relations: 관계
-            Routing: 라우팅
-            Schema: 스키마
-            Security: 보안
-            Services: 서비스
-            Sessions: 세션
-            Testing: 테스트
-            Transactions: 트랜잭션
-            Upgrading: 업그레이드
-            Validation: 유효성 검사
-            Version (4.0): 버전 (4.0)
-            WebSockets: 웹소켓
-            Welcome: 환영합니다
-          site_name: Vapor 문서
-        - build: true
-          default: false
-          locale: ja
-          name: 日本語
-          nav_translations:
-            Advanced: 上級
-            Async: 非同期
-            Authentication: 認証
-            Basics: 基礎
-            Client: クライアント
-            Commands: コマンド
-            Content: コンテンツ
-            Contributing: 貢献
-            Contributing Guide: 貢献ガイド
-            Controllers: コントローラー
-            Crypto: 暗号
-            Custom Tags: カスタムタグ
-            Deploy: デプロイ
-            Environment: 環境
-            Errors: エラー
-            Files: ファイル
-            Folder Structure: フォルダ構造
-            Getting Started: はじめに
-            Install: インストール
-            Legacy Docs: レガシードキュメント
-            Logging: ロギング
-            Migrations: マイグレーション
-            Model: モデル
-            Overview: 概要
-            Passwords: パスワード
-            Query: クエリ
-            Queues: キュー
-            Relations: 関係
-            Release Notes: リリースノート
-            Routing: ルーティング
-            Schema: スキーマ
-            Security: セキュリティ
-            Services: サービス
-            Sessions: セッション
-            Testing: テスト
-            Transactions: トランザクション
-            Upgrading: アップグレード
-            Validation: バリデーション
-            Welcome: ようこそ
-          site_name: Vapor ドキュメント
+            APNS: 苹果推送服务
+            Advanced: 进阶
+            Async: 异步
+            Authentication: 认证
+            Basics: 入门
+            Client: 客户端
+            Commands: 命令
+            Content: 内容
+            Contributing: 贡献
+            Contributing Guide: 贡献指南
+            Crypto: 加密
+            Custom Tags: 自定义标签
+            Deploy: 部署
+            Environment: 环境
+            Errors: 错误
+            Files: 文件
+            Fluent: Fluent
+            Folder Structure: 项目结构
+            Getting Started: 开始
+            Hello, world: 你好世界
+            Install: 安装
+            JWT: JWT
+            Leaf: Leaf
+            Logging: 日志
+            Middleware: 中间件
+            Migrations: 迁移
+            Model: 模型
+            Overview: 概述
+            Passwords: 密码
+            Query: 查询
+            Queues: 队列
+            Redis: Redis
+            Relations: 关联
+            Routing: 路由
+            Schema: 模式
+            Security: 安全
+            Server: 服务器
+            Services: 服务
+            Sessions: 会话
+            SwiftPM: Swift 包管理器
+            Testing: 测试
+            Transactions: 事务
+            Validation: 验证
+            Version (4.0): 版本 (4.0)
+            WebSockets: 即时通讯
+            Welcome: 序言
+            Xcode: Xcode
+          site_name: Vapor 中文文档
       reconfigure_material: true
       reconfigure_search: false
 nav:


### PR DESCRIPTION
This proposal is to have the original languages in the `translation_needed.description.leaf` file, and also reorder the languages in both `translation_needed` and `mkdocs.yml` to follow the **ISO 639-1** language codes as used in `fixSearchIndex.swift` file, to have a unified order.