### PR TITLE
Fix "Model Coupling" example in Schema docs

### DIFF
--- a/docs/fluent/schema.es.md
+++ b/docs/fluent/schema.es.md
@@ -390,7 +390,7 @@ struct UserNameMigration: AsyncMigration {
          // Esto tampoco intenta dividir el nombre en nombre y apellido,
          // ya que eso requiere sintaxis específica de la base de datos.
          try await User.query(on: database)
-             .set(["first_name": .sql(embed: "name"))
+             .set(["first_name": .sql(embed: "name")])
              .run()
 
         try await database.schema("users")
@@ -403,7 +403,7 @@ struct UserNameMigration: AsyncMigration {
             .field("name", .string, .required)
             .update()
         try await User.query(on: database)
-            .set(["name": .sql(embed: "concat(first_name, ' ', last_name)"))
+            .set(["name": .sql(embed: "concat(first_name, ' ', last_name)")])
             .run()
         try await database.schema("users")
             .deleteField("first_name")

--- a/docs/fluent/schema.md
+++ b/docs/fluent/schema.md
@@ -390,7 +390,7 @@ struct UserNameMigration: AsyncMigration {
         // This also doesn't try to deal with splitting the name into first and last,
         // as that requires database-specific syntax.
         try await User.query(on: database)
-            .set(["first_name": .sql(embed: "name"))
+            .set(["first_name": .sql(embed: "name")])
             .run()
 
         try await database.schema("users")
@@ -403,7 +403,7 @@ struct UserNameMigration: AsyncMigration {
             .field("name", .string, .required)
             .update()
         try await User.query(on: database)
-            .set(["name": .sql(embed: "concat(first_name, ' ', last_name)"))
+            .set(["name": .sql(embed: "concat(first_name, ' ', last_name)")])
             .run()
         try await database.schema("users")
             .deleteField("first_name")


### PR DESCRIPTION
Amends the `UserNameMigration` code example in the "Model Coupling" section of the Schema documentation with correct syntax. Added closing square brackets to the dictionary literals passed into `QueryBuilder.set(_ data:)` in multiple places.