### PR TITLE
Suggest "Vapor for VS Code" extension

### DIFF
--- a/docs/getting-started/hello-world.it.md
+++ b/docs/getting-started/hello-world.it.md
@@ -46,12 +46,15 @@ Nella parte superiore della finestra, alla destra dei pulsanti Play e Stop, clic
 Dovresti ora veder apparire la Console nella parte inferiore della finestra di Xcode.
 
 ```sh
-[ INFO ] Server starting on http://
+[ INFO ] Server starting on http://127.0.0.1:8080
 ```
 
 ### Linux
 
 Su Linux e altri sistemi operativi (e anche su macOS se non volete utilizzare Xcode) puoi modificare il progetto nel tuo editor preferito, come Vim o VSCode. Per maggiori dettagli su come configurare altri IDE, consulta le [Guide di Swift sul Server](https://github.com/swift-server/guides/blob/main/docs/setup-and-ide-alternatives.md)
+
+!!! tip "Suggerimento"
+    Se usi VSCode come editor di testo, raccomandiamo di installare l'estensione ufficiale di Vapor: [Vapor for VS Code](https://marketplace.visualstudio.com/items?itemName=Vapor.vapor-vscode).
 
 Per compilare ed eseguire il progetto, nel Terminale esegui:
 

--- a/docs/getting-started/hello-world.md
+++ b/docs/getting-started/hello-world.md
@@ -60,6 +60,9 @@ You should see the Console pop up at the bottom of the Xcode window.
 
 On Linux and other OSes (and even on macOS if you don't want to use Xcode) you can edit the project in your favorite editor of choice, such as Vim or VSCode. See the [Swift Server Guides](https://github.com/swift-server/guides/blob/main/docs/setup-and-ide-alternatives.md) for up to date details on setting up other IDEs.
 
+!!! tip
+    If you're using VSCode as your code editor, we recommend installing the official Vapor extension: [Vapor for VS Code](https://marketplace.visualstudio.com/items?itemName=Vapor.vapor-vscode).
+
 To build and run your project, in Terminal run:
 
 ```sh

--- a/docs/leaf/getting-started.es.md
+++ b/docs/leaf/getting-started.es.md
@@ -85,7 +85,7 @@ Hello, #(name)!
 ```
 
 !!! tip "Consejo"
-    Si estás usando VSCode como tu editor de código, te recomendamos instalar la extensión de Leaf para habilitar el resaltado de sintaxis: [Leaf HTML](https://marketplace.visualstudio.com/items?itemName=Francisco.html-leaf).
+    Si estás usando VSCode como tu editor de código, te recomendamos instalar la extensión de Vapor para habilitar el resaltado de sintaxis: [Vapor for VS Code](https://marketplace.visualstudio.com/items?itemName=Vapor.vapor-vscode).
 
 Luego, registra una ruta (generalmente en `routes.swift` o en un controlador) para renderizar la vista.
 

--- a/docs/leaf/getting-started.it.md
+++ b/docs/leaf/getting-started.it.md
@@ -74,7 +74,7 @@ Hello, #(name)!
 ```
 
 !!! tip
-    Se usi VSCode come editor di testo, raccomandiamo di installare l'estensione Leaf per abilitare l'evidenziazione della sintassi: [Leaf HTML](https://marketplace.visualstudio.com/items?itemName=Francisco.html-leaf).
+    Se usi VSCode come editor di testo, raccomandiamo di installare l'estensione di Vapor per abilitare l'evidenziazione della sintassi: [Vapor for VS Code](https://marketplace.visualstudio.com/items?itemName=Vapor.vapor-vscode).
 
 Quindi, registra una route (di solito fatto in `routes.swift` o un controller) per renderizzare la view.
 

--- a/docs/leaf/getting-started.ja.md
+++ b/docs/leaf/getting-started.ja.md
@@ -74,7 +74,7 @@ Hello, #(name)!
 ```
 
 !!! tip
-    もし、コードエディタとして VSCode を使用している場合、シンタックスハイライトを有効にするために、Leaf 拡張機能をインストールすることをお勧めします：[Leaf HTML](https://marketplace.visualstudio.com/items?itemName=Francisco.html-leaf)
+    もし、コードエディタとして VSCode を使用している場合、シンタックスハイライトを有効にするために、Vapor 拡張機能をインストールすることをお勧めします：[Vapor for VS Code](https://marketplace.visualstudio.com/items?itemName=Vapor.vapor-vscode)
 
 次に、View をレンダリングするルートを登録します。(通常は、`routes.swift` やコントローラで行います)
 

--- a/docs/leaf/getting-started.md
+++ b/docs/leaf/getting-started.md
@@ -85,7 +85,7 @@ Hello, #(name)!
 ```
 
 !!! tip
-    If you're using VSCode as your code editor, we recommend installing the Leaf extension to enable syntax highlighting: [Leaf HTML](https://marketplace.visualstudio.com/items?itemName=Francisco.html-leaf).
+    If you're using VSCode as your code editor, we recommend installing the Vapor extension to enable syntax highlighting: [Vapor for VS Code](https://marketplace.visualstudio.com/items?itemName=Vapor.vapor-vscode).
 
 Then, register a route (usually done in `routes.swift` or a controller) to render the view.
 

--- a/docs/leaf/getting-started.nl.md
+++ b/docs/leaf/getting-started.nl.md
@@ -75,7 +75,7 @@ Hello, #(name)!
 ```
 
 !!! tip
-    Als je VSCode als code editor gebruikt, raden we aan de Leaf extensie te installeren om syntax highlighting mogelijk te maken: [Leaf HTML](https://marketplace.visualstudio.com/items?itemName=Francisco.html-leaf).
+    Als je VSCode als code editor gebruikt, raden we aan de Vapor extensie te installeren om syntax highlighting mogelijk te maken: [Vapor for VS Code](https://marketplace.visualstudio.com/items?itemName=Vapor.vapor-vscode).
 
 Registreer dan een route (meestal gedaan in `routes.swift` of een controller) om de view te renderen.
 

--- a/docs/leaf/getting-started.pl.md
+++ b/docs/leaf/getting-started.pl.md
@@ -75,7 +75,7 @@ Cześć, #(name)!
 ```
 
 !!! tip
-Jeśli korzystasz z VSCode, rekomendowane jest zainstalowanie rozszerzenia do Leaf (Podpowiedzi i podkreślanie składni): [Leaf HTML](https://marketplace.visualstudio.com/items?itemName=Francisco.html-leaf).
+Jeśli korzystasz z VSCode, rekomendowane jest zainstalowanie rozszerzenia do Vapor (Podpowiedzi i podkreślanie składni): [Vapor for VS Code](https://marketplace.visualstudio.com/items?itemName=Vapor.vapor-vscode).
 
 Następnie: Dodaj ścieżkę (przeważnie w `routes.swift` lub w kontrolerze), żeby wyrenderować widok.
 

--- a/docs/leaf/getting-started.zh.md
+++ b/docs/leaf/getting-started.zh.md
@@ -75,7 +75,7 @@ Hello, #(name)!
 ```
 
 !!! tip "建议"
-    如果你正在使用 VSCode 作为代码编辑器，我们推荐安装 [Leaf HTML](https://marketplace.visualstudio.com/items?itemName=Francisco.html-leaf) 扩展，以启用语法高亮功能。
+    如果你正在使用 VSCode 作为代码编辑器，我们推荐安装 [Vapor for VS Code](https://marketplace.visualstudio.com/items?itemName=Vapor.vapor-vscode) 扩展，以启用语法高亮功能。
 
 然后，注册一个路由（通常在 `routes.swift` 中或一个控制器中完成注册）来渲染视图。
 


### PR DESCRIPTION
- Replace "Leaf HTML" extension with "Vapor for VS Code"
- Add a new tip in the "Hello World" section suggesting the extension
