### PR TITLE
Remove outdated app.shutdown() requirement from testing docs

### DIFF
--- a/docs/advanced/testing.md
+++ b/docs/advanced/testing.md
@@ -214,13 +214,10 @@ Each function beginning with `test` will run automatically when your app is test
 
 ### Testable Application
 
-Initialize an instance of `Application` using the `.testing` environment. You must call `app.shutdown()` before this application deinitializes.  
-
-The shutdown is necessary to help release the resources that the app has claimed. In particular it is important to release the threads the application requests at startup. If you do not call `shutdown()` on the app after each unit test, you may find your test suite crash with a precondition failure when allocating threads for a new instance of `Application`.
+Initialize an instance of `Application` using the `.testing` environment.
 
 ```swift
 let app = Application(.testing)
-defer { app.shutdown() }
 try configure(app)
 ```
 


### PR DESCRIPTION
## Summary

Removes the outdated warning about calling `app.shutdown()` in tests and the `defer { app.shutdown() }` line from the code example in the testing guide.

## Why this matters

Per #865 and [the discussion in #864](https://github.com/vapor/docs/pull/864), @Joannis confirmed the precondition failure on shutdown has been fixed upstream. The current text tells users they "must call `app.shutdown()`" and warns about crashes, which is no longer accurate and adds unnecessary boilerplate to test code.

## Changes

**File:** `docs/advanced/testing.md`

- Removed the "You must call `app.shutdown()`" sentence and the two-paragraph explanation about precondition failures
- Removed `defer { app.shutdown() }` from the code example
- Kept the translated files unchanged (separate issue for translation updates)

Closes #865

This contribution was developed with AI assistance (Claude Code).